### PR TITLE
Update UnrarKit.podspec to traverse Classes subdirectories

### DIFF
--- a/UnrarKit.podspec
+++ b/UnrarKit.podspec
@@ -8,8 +8,8 @@ Pod::Spec.new do |s|
   s.source        = { :git => "https://github.com/abbeycode/UnrarKit.git", :tag => "#{s.version}" }
   s.ios.deployment_target = "5.0"
   s.osx.deployment_target = "10.7"
-  s.requires_arc = 'Classes/*'
-  s.source_files = "Classes/*.{mm,m,h}",
+  s.requires_arc = 'Classes/**/*'
+  s.source_files = "Classes/**/*.{mm,m,h}",
                    "Libraries/unrar/*.hpp",
                    "Libraries/unrar/rar.cpp",
                    "Libraries/unrar/strlist.cpp",


### PR DESCRIPTION
This should update our podspec so it recursively traverses the "Classes" subdirectory.  We need this now that we have the new "Categories" folder.

I attempted to pull branch v2.3 into my project and it failed due to a missing category.
