### PR TITLE
Add comprehensive logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.9
 
 * Switched to Travis Build Stages instead of the unofficial Travis-After-All (Issue #42)
+* Added detailed logging using new unified logging framework. See [the readme](README.md) for more details (Issue #35)
 
 
 ## 2.8.1

--- a/Classes/URKArchive.mm
+++ b/Classes/URKArchive.mm
@@ -78,6 +78,7 @@ NS_DESIGNATED_INITIALIZER
 }
 
 - (instancetype)init {
+    URKLogError("Attempted to use -init method, which is no longer supported");
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                    reason:@"-init is not a valid initializer for the class URKArchive"
                                  userInfo:nil];
@@ -111,7 +112,12 @@ NS_DESIGNATED_INITIALIZER
 
 - (instancetype)initWithFile:(NSURL *)fileURL password:(NSString*)password error:(NSError **)error
 {
+    URKCreateActivity("Init Archive");
+
+    URKLogInfo("Initializing archive with URL %{public}@, path %{public}@, password %{public}@", fileURL, fileURL.path, [password length] != 0 ? @"given" : @"not given");
+    
     if (!fileURL) {
+        URKLogError("Cannot initialize archive with nil URL");
         return nil;
     }
 
@@ -119,6 +125,8 @@ NS_DESIGNATED_INITIALIZER
         if (error) {
             *error = nil;
         }
+
+        URKLogDebug("Initializing private fields");
 
         NSError *bookmarkError = nil;
         _fileBookmark = [fileURL bookmarkDataWithOptions:0
@@ -148,6 +156,8 @@ NS_DESIGNATED_INITIALIZER
 
 - (NSURL *)fileURL
 {
+    URKCreateActivity("Read Archive URL");
+
     BOOL bookmarkIsStale = NO;
     NSError *error = nil;
 
@@ -163,6 +173,7 @@ NS_DESIGNATED_INITIALIZER
     }
 
     if (bookmarkIsStale) {
+        URKLogDebug("Refreshing stale bookmark");
         self.fileBookmark = [result bookmarkDataWithOptions:0
                              includingResourceValuesForKeys:@[]
                                               relativeToURL:nil
@@ -178,6 +189,8 @@ NS_DESIGNATED_INITIALIZER
 
 - (NSString *)filename
 {
+    URKCreateActivity("Read Archive Filename");
+    
     NSURL *url = self.fileURL;
 
     if (!url) {
@@ -189,6 +202,8 @@ NS_DESIGNATED_INITIALIZER
 
 - (NSNumber *)uncompressedSize
 {
+    URKCreateActivity("Read Archive Uncompressed Size");
+
     NSError *listError = nil;
     NSArray *fileInfo = [self listFileInfo:&listError];
     
@@ -198,6 +213,7 @@ NS_DESIGNATED_INITIALIZER
     }
     
     if (fileInfo.count == 0) {
+        URKLogInfo("No files in archive. Size == 0");
         return 0;
     }
         
@@ -206,6 +222,8 @@ NS_DESIGNATED_INITIALIZER
 
 - (NSNumber *)compressedSize
 {
+    URKCreateActivity("Read Archive Compressed Size");
+
     NSString *filePath = self.filename;
     
     if (!filePath) {
@@ -213,6 +231,7 @@ NS_DESIGNATED_INITIALIZER
         return nil;
     }
     
+    URKLogInfo("Reading archive file attributes...");
     NSError *attributesError = nil;
     NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath
                                                                                 error:&attributesError];
@@ -232,9 +251,12 @@ NS_DESIGNATED_INITIALIZER
 
 + (BOOL)pathIsARAR:(NSString *)filePath
 {
+    URKCreateActivity("Determining File Type (Path)");
+
     NSFileHandle *handle = [NSFileHandle fileHandleForReadingAtPath:filePath];
 
     if (!handle) {
+        URKLogError("No file handle returned for path: %{public}@", filePath);
         return NO;
     }
 
@@ -242,6 +264,7 @@ NS_DESIGNATED_INITIALIZER
         NSData *fileData = [handle readDataOfLength:8];
 
         if (fileData.length < 8) {
+            URKLogDebug("No file handle returned for path: %{public}@", filePath);
             return NO;
         }
 
@@ -254,19 +277,24 @@ NS_DESIGNATED_INITIALIZER
             dataBytes[3] != 0x21 ||
             dataBytes[4] != 0x1A ||
             dataBytes[5] != 0x07) {
+            URKLogDebug("File is not a RAR. Magic numbers != 'Rar!..'");
             return NO;
         }
 
         // Check for v1.5 and on
         if (dataBytes[6] == 0x00) {
+            URKLogDebug("File is a RAR >= v1.5");
             return YES;
         }
 
         // Check for v5.0
         if (dataBytes[6] == 0x01 &&
             dataBytes[7] == 0x00) {
+            URKLogDebug("File is a RAR >= v5.0");
             return YES;
         }
+
+        URKLogDebug("File is not a ZIP. Unknown contents in 7th and 8th bytes (%02X %02X)", dataBytes[6], dataBytes[7]);
     }
     @finally {
         [handle closeFile];
@@ -277,7 +305,10 @@ NS_DESIGNATED_INITIALIZER
 
 + (BOOL)urlIsARAR:(NSURL *)fileURL
 {
+    URKCreateActivity("Determining File Type (URL)");
+
     if (!fileURL || !fileURL.path) {
+        URKLogDebug("File is not a RAR: nil URL or path");
         return NO;
     }
 
@@ -291,29 +322,43 @@ NS_DESIGNATED_INITIALIZER
 
 - (NSArray<NSString*> *)listFilenames:(NSError **)error
 {
+    URKCreateActivity("Listing Filenames");
+
     NSArray *files = [self listFileInfo:error];
     return [files valueForKey:@"filename"];
 }
 
 - (NSArray<URKFileInfo*> *)listFileInfo:(NSError **)error
 {
+    URKCreateActivity("Listing File Info");
+
     __block NSMutableArray *fileInfos = [NSMutableArray array];
 
     BOOL success = [self performActionWithArchiveOpen:^(NSError **innerError) {
+        URKCreateActivity("Performing List Action");
+
         int RHCode = 0, PFCode = 0;
 
+        URKLogInfo("Reading through RAR header looking for files...");
+        
         while ((RHCode = RARReadHeaderEx(_rarFile, header)) == 0) {
+            URKLogDebug("Adding object");
             [fileInfos addObject:[URKFileInfo fileInfo:header]];
 
+            URKLogDebug("Skipping to next file...");
             if ((PFCode = RARProcessFile(_rarFile, RAR_SKIP, NULL, NULL)) != 0) {
-                [self assignError:error code:(NSInteger)PFCode];
+                NSString *errorName = nil;
+                [self assignError:error code:(NSInteger)PFCode errorName:&errorName];
+                URKLogError("Error skipping to next header file: %@ (%d)", errorName, PFCode);
                 fileInfos = nil;
                 return;
             }
         }
 
         if (RHCode != ERAR_SUCCESS && RHCode != ERAR_END_ARCHIVE) {
-            [self assignError:error code:RHCode];
+            NSString *errorName = nil;
+            [self assignError:error code:RHCode errorName:&errorName];
+            URKLogError("Error reading RAR header: %@ (%d)", errorName, RHCode);
             fileInfos = nil;
         }
     } inMode:RAR_OM_LIST_INCSPLIT error:error];
@@ -322,6 +367,7 @@ NS_DESIGNATED_INITIALIZER
         return nil;
     }
 
+    URKLogDebug("Found %lu files", fileInfos.count);
     return [NSArray arrayWithArray:fileInfos];
 }
 
@@ -330,6 +376,8 @@ NS_DESIGNATED_INITIALIZER
               progress:(void (^)(URKFileInfo *currentFile, CGFloat percentArchiveDecompressed))progress
                  error:(NSError **)error
 {
+    URKCreateActivity("Extracting Files to Directory");
+
     __block BOOL result = YES;
 
     NSError *listError = nil;
@@ -349,23 +397,30 @@ NS_DESIGNATED_INITIALIZER
     __block long long bytesDecompressed = 0;
 
     BOOL success = [self performActionWithArchiveOpen:^(NSError **innerError) {
+        URKCreateActivity("Performing File Extraction");
+
         int RHCode = 0, PFCode = 0;
         URKFileInfo *fileInfo;
 
+        URKLogInfo("Reading through RAR header looking for files...");
         while ((RHCode = RARReadHeaderEx(_rarFile, header)) == ERAR_SUCCESS) {
             fileInfo = [URKFileInfo fileInfo:header];
-
+            URKLogDebug("Extracting %{public}@", fileInfo.filename);
+            
             if (progress) {
                 progress(fileInfo, bytesDecompressed / totalSize.floatValue);
             }
 
             if ([self headerContainsErrors:error]) {
+                URKLogError("Header contains an error")
                 result = NO;
                 return;
             }
 
             if ((PFCode = RARProcessFile(_rarFile, RAR_EXTRACT, (char *) filePath.UTF8String, NULL)) != 0) {
-                [self assignError:error code:(NSInteger)PFCode];
+                NSString *errorName = nil;
+                [self assignError:error code:(NSInteger)PFCode errorName:&errorName];
+                URKLogError("Error extracting file: %@ (%d)", errorName, PFCode);
                 result = NO;
                 return;
             }
@@ -374,7 +429,9 @@ NS_DESIGNATED_INITIALIZER
         }
 
         if (RHCode != ERAR_SUCCESS && RHCode != ERAR_END_ARCHIVE) {
-            [self assignError:error code:RHCode];
+            NSString *errorName = nil;
+            [self assignError:error code:RHCode errorName:&errorName];
+            URKLogError("Error reading file header: %@ (%d)", errorName, RHCode);
             result = NO;
         }
 
@@ -398,37 +455,50 @@ NS_DESIGNATED_INITIALIZER
                        progress:(void (^)(CGFloat percentDecompressed))progress
                           error:(NSError **)error
 {
+    URKCreateActivity("Extracting Data from File");
+
     __block NSData *result = nil;
 
     BOOL success = [self performActionWithArchiveOpen:^(NSError **innerError) {
+        URKCreateActivity("Performing Extraction");
+
         int RHCode = 0, PFCode = 0;
         URKFileInfo *fileInfo;
 
+        URKLogInfo("Reading through RAR header looking for files...");
         while ((RHCode = RARReadHeaderEx(_rarFile, header)) == ERAR_SUCCESS) {
             if ([self headerContainsErrors:error]) {
+                URKLogError("Header contains an error")
                 return;
             }
 
             fileInfo = [URKFileInfo fileInfo:header];
 
             if ([fileInfo.filename isEqualToString:filePath]) {
+                URKLogDebug("Extracting %{public}@", fileInfo.filename);
                 break;
             }
             else {
+                URKLogDebug("Skipping %{public}@", fileInfo.filename);
                 if ((PFCode = RARProcessFileW(_rarFile, RAR_SKIP, NULL, NULL)) != 0) {
-                    [self assignError:error code:(NSInteger)PFCode];
+                    NSString *errorName = nil;
+                    [self assignError:error code:(NSInteger)PFCode errorName:&errorName];
+                    URKLogError("Error skipping file: %@ (%d)", errorName, PFCode);
                     return;
                 }
             }
         }
 
         if (RHCode != ERAR_SUCCESS) {
-            [self assignError:error code:RHCode];
+            NSString *errorName = nil;
+            [self assignError:error code:RHCode errorName:&errorName];
+            URKLogError("Error reading file header: %@ (%d)", errorName, RHCode);
             return;
         }
 
         // Empty file, or a directory
         if (fileInfo.uncompressedSize == 0) {
+            URKLogDebug("%{public}@ is empty or a directory", fileInfo.filename);
             result = [NSData data];
             return;
         }
@@ -443,6 +513,7 @@ NS_DESIGNATED_INITIALIZER
 
         RARSetCallback(_rarFile, BufferedReadCallbackProc, (long)(__bridge void *) self);
         self.bufferedReadBlock = ^void(NSData *dataChunk) {
+            URKLogDebug("Appending buffered data (%lu bytes)", dataChunk.length);
             [fileData appendData:dataChunk];
 
             bytesRead += dataChunk.length;
@@ -452,10 +523,13 @@ NS_DESIGNATED_INITIALIZER
             }
         };
 
+        URKLogInfo("Processing file...");
         PFCode = RARProcessFile(_rarFile, RAR_TEST, NULL, NULL);
 
         if (PFCode != 0) {
-            [self assignError:error code:(NSInteger)PFCode];
+            NSString *errorName = nil;
+            [self assignError:error code:(NSInteger)PFCode errorName:&errorName];
+            URKLogError("Error extracting file data: %@ (%d)", errorName, PFCode);
             return;
         }
 
@@ -472,6 +546,10 @@ NS_DESIGNATED_INITIALIZER
 - (BOOL)performOnFilesInArchive:(void(^)(URKFileInfo *fileInfo, BOOL *stop))action
                           error:(NSError **)error
 {
+    URKCreateActivity("Performing Action on Each File");
+
+    URKLogInfo("Listing file info");
+    
     NSError *listError = nil;
     NSArray *fileInfo = [self listFileInfo:&listError];
 
@@ -485,11 +563,22 @@ NS_DESIGNATED_INITIALIZER
         return NO;
     }
 
+    URKLogInfo("Sorting file info by name/path");
+    
     NSArray *sortedFileInfo = [fileInfo sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"filename" ascending:YES]]];
 
-    [sortedFileInfo enumerateObjectsUsingBlock:^(URKFileInfo *info, NSUInteger idx, BOOL *stop) {
-        action(info, stop);
-    }];
+    {
+        URKCreateActivity("Iterating Each File Info");
+        
+        [sortedFileInfo enumerateObjectsUsingBlock:^(URKFileInfo *info, NSUInteger idx, BOOL *stop) {
+            URKLogDebug("Performing action on %{public}@", info.filename);
+            action(info, stop);
+            
+            if (stop) {
+                URKLogInfo("Action dictated an early stop");
+            }
+        }];
+    }
 
     return YES;
 }
@@ -497,20 +586,31 @@ NS_DESIGNATED_INITIALIZER
 - (BOOL)performOnDataInArchive:(void (^)(URKFileInfo *, NSData *, BOOL *))action
                          error:(NSError **)error
 {
+    URKCreateActivity("Performing Action on Each File's Data");
+
     BOOL success = [self performActionWithArchiveOpen:^(NSError **innerError) {
         int RHCode = 0, PFCode = 0;
 
         BOOL stop = NO;
 
+        URKLogInfo("Reading through RAR header looking for files...");
         while ((RHCode = RARReadHeaderEx(_rarFile, header)) == 0) {
-            if (stop || [self headerContainsErrors:error]) {
+            if (stop) {
+                URKLogDebug("Action dictated an early stop");
                 return;
             }
-
+            
+            if ([self headerContainsErrors:error]) {
+                URKLogError("Header contains an error")
+                return;
+            }
+            
             URKFileInfo *info = [URKFileInfo fileInfo:header];
+            URKLogDebug("Performing action on %{public}@", info.filename);
 
             // Empty file, or a directory
             if (info.uncompressedSize == 0) {
+                URKLogDebug("%{public}@ is an empty file, or a directory", info.filename);
                 action(info, [NSData data], &stop);
                 continue;
             }
@@ -520,19 +620,25 @@ NS_DESIGNATED_INITIALIZER
 
             RARSetCallback(_rarFile, CallbackProc, (long) &callBackBuffer);
 
+            URKLogInfo("Processing file...");
             PFCode = RARProcessFile(_rarFile, RAR_TEST, NULL, NULL);
 
             if (PFCode != 0) {
-                [self assignError:error code:(NSInteger)PFCode];
+                NSString *errorName = nil;
+                [self assignError:error code:(NSInteger)PFCode errorName:&errorName];
+                URKLogError("Error processing file: %@ (%d)", errorName, PFCode);
                 return;
             }
 
+            URKLogDebug("Performing action on data (%lld bytes)", info.uncompressedSize);
             NSData *data = [NSData dataWithBytesNoCopy:buffer length:(NSUInteger)info.uncompressedSize freeWhenDone:YES];
             action(info, data, &stop);
         }
 
         if (RHCode != ERAR_SUCCESS && RHCode != ERAR_END_ARCHIVE) {
-            [self assignError:error code:RHCode];
+            NSString *errorName = nil;
+            [self assignError:error code:RHCode errorName:&errorName];
+            URKLogError("Error reading file header: %@ (%d)", errorName, RHCode);
             return;
         }
     } inMode:RAR_OM_EXTRACT error:error];
@@ -544,53 +650,76 @@ NS_DESIGNATED_INITIALIZER
                               error:(NSError **)error
                              action:(void(^)(NSData *dataChunk, CGFloat percentDecompressed))action
 {
+    URKCreateActivity("Extracting Buffered Data");
+
     NSError *innerError = nil;
 
     BOOL success = [self performActionWithArchiveOpen:^(NSError **innerError) {
+        URKCreateActivity("Performing action");
+
         int RHCode = 0, PFCode = 0;
         URKFileInfo *fileInfo;
 
+        URKLogInfo("Looping through files, looking for %@...", fileInfo.filename);
+        
         while ((RHCode = RARReadHeaderEx(_rarFile, header)) == ERAR_SUCCESS) {
             if ([self headerContainsErrors:error]) {
+                URKLogDebug("Header contains error")
                 return;
             }
 
+            URKLogDebug("Getting file info from header");
             fileInfo = [URKFileInfo fileInfo:header];
 
             if ([fileInfo.filename isEqualToString:filePath]) {
+                URKLogDebug("Found desired file");
                 break;
             }
             else {
+                URKLogDebug("Skipping file...");
                 if ((PFCode = RARProcessFile(_rarFile, RAR_SKIP, NULL, NULL)) != 0) {
-                    [self assignError:error code:(NSInteger)PFCode];
+                    NSString *errorName = nil;
+                    [self assignError:error code:(NSInteger)PFCode errorName:&errorName];
+                    URKLogError("Failed to skip file: %@ (%d)", errorName, PFCode);
                     return;
                 }
             }
         }
 
         if (RHCode != ERAR_SUCCESS) {
-            [self assignError:error code:RHCode];
+            NSString *errorName = nil;
+            [self assignError:error code:RHCode errorName:&errorName];
+            URKLogError("Header read yielded error: %@ (%d)", errorName, RHCode);
             return;
         }
 
         // Empty file, or a directory
         if (fileInfo.uncompressedSize == 0) {
+            URKLogInfo("File is empty or a directory");
             return;
         }
 
         CGFloat totalBytes = fileInfo.uncompressedSize;
         __block long long bytesRead = 0;
 
+        // Repeating the argument instead of using positional specifiers, because they don't work with the {} formatters
+        URKLogDebug("Uncompressed size: %{iec-bytes}lld (%lld bytes) in file", (long long)totalBytes, (long long)totalBytes);
+
         RARSetCallback(_rarFile, BufferedReadCallbackProc, (long)(__bridge void *) self);
         self.bufferedReadBlock = ^void(NSData *dataChunk) {
             bytesRead += dataChunk.length;
-            action(dataChunk, bytesRead / totalBytes);
+            CGFloat progress = bytesRead / totalBytes;
+            URKLogDebug("Read data chunk of size %lu (%.3f%% complete). Calling handler...", dataChunk.length, progress * 100);
+            action(dataChunk, progress);
         };
 
+        URKLogDebug("Processing file...");
         PFCode = RARProcessFile(_rarFile, RAR_TEST, NULL, NULL);
 
         if (PFCode != 0) {
-            [self assignError:error code:(NSInteger)PFCode];
+            NSString *errorName = nil;
+            [self assignError:error code:(NSInteger)PFCode errorName:&errorName];
+            URKLogError("Error processing file: %@ (%d)", errorName, PFCode);
         }
     } inMode:RAR_OM_EXTRACT error:&innerError];
 
@@ -607,73 +736,92 @@ NS_DESIGNATED_INITIALIZER
 
 - (BOOL)isPasswordProtected
 {
+    URKCreateActivity("Checking Password Protection");
+
     @try {
+        URKLogDebug("Opening archive");
+        
         NSError *error = nil;
         if (![self _unrarOpenFile:self.filename
                            inMode:RAR_OM_EXTRACT
                      withPassword:nil
                             error:&error])
         {
+            URKLogError("Failed to open archive while checking for password: %{public}@", error);
             return NO;
         }
 
-        if (error) {
-            URKLogError("Error checking for password: %{public}@", error);
-            return NO;
-        }
-
+        URKLogDebug("Reading header and starting processing...");
+        
         int RHCode = RARReadHeaderEx(_rarFile, header);
         int PFCode = RARProcessFile(_rarFile, RAR_SKIP, NULL, NULL);
 
+        URKLogDebug("Checking header");
         if ([self headerContainsErrors:&error]) {
             if (error.code == ERAR_MISSING_PASSWORD) {
+                URKLogDebug("Password is missing");
                 return YES;
             }
 
             URKLogError("Errors in header while checking for password: %{public}@", error);
         }
 
-        if (RHCode == ERAR_MISSING_PASSWORD || PFCode == ERAR_MISSING_PASSWORD)
+        if (RHCode == ERAR_MISSING_PASSWORD || PFCode == ERAR_MISSING_PASSWORD) {
+            URKLogDebug("Missing password indicated by RHCode (%d) or PFCode (%d)", RHCode, PFCode);
             return YES;
+        }
     }
     @finally {
         [self closeFile];
     }
 
+    URKLogDebug("Archive is not password protected");
     return NO;
 }
 
 - (BOOL)validatePassword
 {
+    URKCreateActivity("Validating Password");
+
     __block NSError *error = nil;
-    __block BOOL result = NO;
+    __block BOOL passwordIsGood = YES;
 
     BOOL success = [self performActionWithArchiveOpen:^(NSError **innerError) {
-        if (error) {
-            URKLogError("Error validating password: %{public}@", error);
-            return;
-        }
+        URKCreateActivity("Performing action");
 
+        URKLogDebug("Opening and processing archive...");
+        
         int RHCode = RARReadHeaderEx(_rarFile, header);
         int PFCode = RARProcessFile(_rarFile, RAR_TEST, NULL, NULL);
 
-        if ([self headerContainsErrors:&error] && error.code == ERAR_MISSING_PASSWORD) {
-            URKLogError("Errors in header while validating password: %{public}@", error);
+        if ([self headerContainsErrors:innerError]) {
+            if (error.code == ERAR_MISSING_PASSWORD) {
+                URKLogDebug("Password invalidated by header");
+                passwordIsGood = NO;
+            }
+            else {
+                URKLogError("Errors in header while validating password: %{public}@", error);
+            }
+
             return;
         }
 
-        if (RHCode == ERAR_MISSING_PASSWORD
-            || PFCode == ERAR_MISSING_PASSWORD
-            || RHCode == ERAR_BAD_DATA
-            || PFCode == ERAR_BAD_DATA
-            || RHCode == ERAR_BAD_PASSWORD
-            || PFCode == ERAR_BAD_PASSWORD)
+        if (RHCode == ERAR_MISSING_PASSWORD || PFCode == ERAR_MISSING_PASSWORD
+            || RHCode == ERAR_BAD_DATA || PFCode == ERAR_BAD_DATA
+            || RHCode == ERAR_BAD_PASSWORD || PFCode == ERAR_BAD_PASSWORD)
+        {
+            URKLogDebug("Missing/bad password indicated by RHCode (%d) or PFCode (%d)", RHCode, PFCode);
+            passwordIsGood = NO;
             return;
-
-        result = YES;
+        }
     } inMode:RAR_OM_EXTRACT error:&error];
 
-    return success && result;
+    if (!success) {
+        URKLogError("Error validating password: %{public}@", error);
+        return NO;
+    }
+    
+    return passwordIsGood;
 }
 
 
@@ -682,13 +830,17 @@ NS_DESIGNATED_INITIALIZER
 
 
 int CALLBACK CallbackProc(UINT msg, long UserData, long P1, long P2) {
+    URKCreateActivity("CallbackProc");
+
     UInt8 **buffer;
 
     switch(msg) {
         case UCM_CHANGEVOLUME:
+            URKLogDebug("msg: UCM_CHANGEVOLUME");
             break;
 
         case UCM_PROCESSDATA:
+            URKLogDebug("msg: UCM_PROCESSDATA; Copying data");
             buffer = (UInt8 **) UserData;
             memcpy(*buffer, (UInt8 *)P1, P2);
             // advance the buffer ptr, original m_buffer ptr is untouched
@@ -696,6 +848,7 @@ int CALLBACK CallbackProc(UINT msg, long UserData, long P1, long P2) {
             break;
 
         case UCM_NEEDPASSWORD:
+            URKLogDebug("msg: UCM_NEEDPASSWORD");
             break;
     }
 
@@ -703,9 +856,11 @@ int CALLBACK CallbackProc(UINT msg, long UserData, long P1, long P2) {
 }
 
 int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2) {
+    URKCreateActivity("BufferedReadCallbackProc");
     URKArchive *refToSelf = (__bridge URKArchive *)(void *)UserData;
 
     if (msg == UCM_PROCESSDATA) {
+        URKLogDebug("msg: UCM_PROCESSDATA; Copying data chunk and calling read block");
         NSData *dataChunk = [NSData dataWithBytesNoCopy:(UInt8 *)P1 length:P2 freeWhenDone:NO];
         refToSelf.bufferedReadBlock(dataChunk);
     }
@@ -722,35 +877,65 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
                               inMode:(NSInteger)mode
                                error:(NSError **)error
 {
+    URKCreateActivity("-performActionWithArchiveOpen:inMode:error:");
+
     @synchronized(self.threadLock) {
+        URKLogDebug("Entered lock");
+        
         if (error) {
+            URKLogDebug("Error pointer passed in");
             *error = nil;
         }
 
+        URKLogDebug("Opening archive");
+        NSError *openFileError = nil;
+        
         if (![self _unrarOpenFile:self.filename
                            inMode:mode
                      withPassword:self.password
-                            error:error]) {
+                            error:&openFileError]) {
+            URKLogError("Failed to open archive: %@", openFileError);
+            
+            if (error) {
+                *error = openFileError;
+            }
+            
             return NO;
         }
 
+        NSError *actionError = nil;
+        
         @try {
-            action(error);
+            URKLogDebug("Calling action block");
+            action(&actionError);
         }
         @finally {
             [self closeFile];
         }
 
-        return !error || !*error;
+        if (actionError) {
+            URKLogError("Action block returned error: %@", actionError);
+            
+            if (error){
+                *error = actionError;
+            }
+        }
+        
+        return !actionError;
     }
 }
 
 - (BOOL)_unrarOpenFile:(NSString *)rarFile inMode:(NSInteger)mode withPassword:(NSString *)aPassword error:(NSError **)error
 {
+    URKCreateActivity("-_unrarOpenFile:inMode:withPassword:error:");
+
     if (error) {
+        URKLogDebug("Error pointer passed in");
         *error = nil;
     }
 
+    URKLogDebug("Zeroing out fields...");
+    
     ErrHandler.Clean();
 
     header = new RARHeaderDataEx;
@@ -758,18 +943,25 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
 	flags = new RAROpenArchiveDataEx;
     bzero(flags, sizeof(RAROpenArchiveDataEx));
 
+    URKLogDebug("Setting archive name...");
+    
 	const char *filenameData = (const char *) [rarFile UTF8String];
 	flags->ArcName = new char[strlen(filenameData) + 1];
 	strcpy(flags->ArcName, filenameData);
 	flags->OpenMode = (uint)mode;
 
+    URKLogDebug("Opening archive %{public}@...", rarFile);
+    
 	_rarFile = RAROpenArchiveEx(flags);
 	if (_rarFile == 0 || flags->OpenResult != 0) {
-        [self assignError:error code:(NSInteger)flags->OpenResult];
-		return NO;
+        NSString *errorName = nil;
+        [self assignError:error code:(NSInteger)flags->OpenResult errorName:&errorName];
+        URKLogError("Error opening archive: %@ (%d)", errorName, flags->OpenResult);
+        return NO;
     }
 
     if(aPassword != nil) {
+        URKLogDebug("Setting password...");
         char *password = (char *) [aPassword UTF8String];
         RARSetPassword(_rarFile, password);
     }
@@ -777,10 +969,17 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
 	return YES;
 }
 
-- (BOOL)closeFile;
+- (BOOL)closeFile
 {
-    if (_rarFile)
+    URKCreateActivity("-closeFile");
+
+    if (_rarFile) {
+        URKLogDebug("Closing archive %{public}@...", self.filename);
         RARCloseArchive(_rarFile);
+    }
+    
+    URKLogDebug("Cleaning up fields...");
+    
     _rarFile = 0;
 
     if (flags)
@@ -859,14 +1058,16 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
     return errorName;
 }
 
-- (BOOL)assignError:(NSError **)error code:(NSInteger)errorCode
+- (BOOL)assignError:(NSError **)error code:(NSInteger)errorCode errorName:(NSString **)outErrorName
 {
     if (error) {
-        NSString *errorName = [self errorNameForErrorCode:errorCode];
+        NSAssert(outErrorName, @"An out variable for errorName must be provided");
+        
+        *outErrorName = [self errorNameForErrorCode:errorCode];
 
         *error = [NSError errorWithDomain:URKErrorDomain
                                      code:errorCode
-                                 userInfo:@{NSLocalizedFailureReasonErrorKey: errorName}];
+                                 userInfo:@{NSLocalizedFailureReasonErrorKey: *outErrorName}];
     }
 
     return NO;
@@ -874,10 +1075,14 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
 
 - (BOOL)headerContainsErrors:(NSError **)error
 {
+    URKCreateActivity("-headerContainsErrors:");
+
     BOOL isPasswordProtected = header->Flags & 0x04;
 
     if (isPasswordProtected && !self.password) {
-        [self assignError:error code:ERAR_MISSING_PASSWORD];
+        NSString *errorName = nil;
+        [self assignError:error code:ERAR_MISSING_PASSWORD errorName:&errorName];
+        URKLogError("Password protected and no password specified: %@ (%d)", errorName, ERAR_MISSING_PASSWORD);
         return YES;
     }
 

--- a/Classes/URKFileInfo.m
+++ b/Classes/URKFileInfo.m
@@ -4,6 +4,7 @@
 //
 
 #import "URKFileInfo.h"
+#import "UnrarKitMacros.h"
 
 #import "NSString+UnrarKit.h"
 
@@ -20,7 +21,11 @@
 
 - (instancetype)initWithFileHeader:(struct RARHeaderDataEx *)fileHeader
 {
+    URKCreateActivity("Init URKFileInfo");
+
     if ((self = [super init])) {
+        URKLogDebug("Setting file info fields");
+        
         _filename = [NSString stringWithUnichars:fileHeader->FileNameW];
         _archiveName = [NSString stringWithUnichars:fileHeader->ArcNameW];
         _uncompressedSize = (long long) fileHeader->UnpSizeHigh << 32 | fileHeader->UnpSize;
@@ -37,6 +42,7 @@
         
         _isDirectory = fileHeader->Flags & RHDF_DIRECTORY;
     }
+
     return self;
 }
 
@@ -47,7 +53,10 @@
 
 - (NSDate *)parseDOSDate:(NSUInteger)dosTime
 {
+    URKCreateActivity("-parseDOSDate:");
+
     if (dosTime == 0) {
+        URKLogDebug("DOS Time == 0");
         return nil;
     }
     

--- a/Classes/UnrarKitMacros.h
+++ b/Classes/UnrarKitMacros.h
@@ -1,0 +1,77 @@
+//
+//  UnrarKitMacros.h
+//  UnrarKit
+//
+//  Created by Dov Frankel on 8/8/17.
+//  Copyright © 2017 Abbey Code. All rights reserved.
+//
+
+#ifndef UnrarKitMacros_h
+#define UnrarKitMacros_h
+
+//#import "Availability.h"
+//#import "AvailabilityInternal.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundef"
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
+
+// iOS 10, macOS 10.12, tvOS 10.0, watchOS 3.0
+#define UNIFIED_LOGGING_SUPPORTED \
+__IPHONE_OS_VERSION_MIN_REQUIRED >= 100000 \
+|| __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200 \
+|| __TV_OS_VERSION_MIN_REQUIRED >= 100000 \
+|| __WATCH_OS_VERSION_MIN_REQUIRED >= 30000
+
+#if UNIFIED_LOGGING_SUPPORTED
+#import <os/log.h>
+
+// Called from +[UnrarKit initialize] and +[URKArchiveTestCase setUp]
+extern os_log_t unrarkit_log; // Declared in URKArchive.m
+#define URKLogInit() unrarkit_log = os_log_create("com.abbey-code.UnrarKit", "General");
+
+#define URKLog(format, ...)      os_log(unrarkit_log, format, ##__VA_ARGS__);
+#define URKLogInfo(format, ...)  os_log_info(unrarkit_log, format, ##__VA_ARGS__);
+#define URKLogDebug(format, ...) os_log_debug(unrarkit_log, format, ##__VA_ARGS__);
+
+#define URKLogError(format, ...) os_log_error(unrarkit_log, format, ##__VA_ARGS__);
+#define URKLogFault(format, ...) os_log_fault(unrarkit_log, format, ##__VA_ARGS__);
+
+#define URKCreateActivity(name) \
+os_activity_t activity = os_activity_create(name, OS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT); \
+os_activity_scope(activity);
+
+
+#else // Fall back to regular NSLog
+
+// No-op, as nothing needs to be initialized
+#define URKLogInit() (void)0
+
+
+// Only used below
+#define _removeLogFormatTokens(format) [@format stringByReplacingOccurrencesOfString:@"{public}" withString:@""]
+#define _stringify(a) #a
+#define _nsLogWithoutWarnings(format, ...) \
+_Pragma( _stringify( clang diagnostic push ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wformat-nonliteral" ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wformat-security" ) ) \
+NSLog(_removeLogFormatTokens(format), ##__VA_ARGS__); \
+_Pragma( _stringify( clang diagnostic pop ) )
+
+// All levels do the same thing
+#define URKLog(format, ...)      _nsLogWithoutWarnings(format, ##__VA_ARGS__);
+#define URKLogInfo(format, ...)  _nsLogWithoutWarnings(format, ##__VA_ARGS__);
+#define URKLogDebug(format, ...) _nsLogWithoutWarnings(format, ##__VA_ARGS__);
+#define URKLogError(format, ...) _nsLogWithoutWarnings(format, ##__VA_ARGS__);
+#define URKLogFault(format, ...) _nsLogWithoutWarnings(format, ##__VA_ARGS__);
+
+// No-op, as no equivalent to Activities exists
+#define URKCreateActivity(name) (void)0
+
+#endif
+
+
+#pragma clang diagnostic pop
+
+#endif /* UnrarKitMacros_h */

--- a/Classes/UnrarKitMacros.h
+++ b/Classes/UnrarKitMacros.h
@@ -26,6 +26,7 @@ __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000 \
 
 #if UNIFIED_LOGGING_SUPPORTED
 #import <os/log.h>
+#import <os/activity.h>
 
 // Called from +[UnrarKit initialize] and +[URKArchiveTestCase setUp]
 extern os_log_t unrarkit_log; // Declared in URKArchive.m
@@ -50,7 +51,9 @@ os_activity_scope(activity);
 
 
 // Only used below
-#define _removeLogFormatTokens(format) [@format stringByReplacingOccurrencesOfString:@"{public}" withString:@""]
+#define _removeLogFormatTokens(format) [[@format \
+    stringByReplacingOccurrencesOfString:@"{public}" withString:@""] \
+    stringByReplacingOccurrencesOfString:@"{iec-bytes}" withString:@""]
 #define _stringify(a) #a
 #define _nsLogWithoutWarnings(format, ...) \
 _Pragma( _stringify( clang diagnostic push ) ) \

--- a/UnrarKit.xcodeproj/project.pbxproj
+++ b/UnrarKit.xcodeproj/project.pbxproj
@@ -187,6 +187,8 @@
 		969BD9E019EDE88E002CE755 /* qopen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FC919ED8B4E00DAF8F1 /* qopen.cpp */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks -Wno-unused-variable"; }; };
 		969BD9E119EDE88E002CE755 /* dll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1818DB722E00B5651B /* dll.cpp */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks -Wno-parentheses"; }; };
 		969BD9E219EDE88E002CE755 /* URKArchive.mm in Sources */ = {isa = PBXBuildFile; fileRef = 489CFA0F128B5169005DCC2A /* URKArchive.mm */; };
+		96BF58BB1F3A487100BC24E1 /* UnrarKitMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 96BF58BA1F3A487100BC24E1 /* UnrarKitMacros.h */; };
+		96BF58BC1F3A487100BC24E1 /* UnrarKitMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 96BF58BA1F3A487100BC24E1 /* UnrarKitMacros.h */; };
 		96DBF7FD1A3F72800033B759 /* NSString+UnrarKit.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96DBF7F81A3F72800033B759 /* NSString+UnrarKit.mm */; };
 		96E5D345198B333200A74340 /* Test Data in Resources */ = {isa = PBXBuildFile; fileRef = 964C8AD018D28F1600AD7321 /* Test Data */; };
 		96EA53331B3B462D00F79DC6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EA53321B3B462D00F79DC6 /* AppDelegate.swift */; };
@@ -437,6 +439,7 @@
 		96853F8518DB722F00B5651B /* win32stm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = win32stm.cpp; sourceTree = "<group>"; };
 		9699F9DA1B3CB83100B6D373 /* UnrarKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UnrarKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		969F17361A60297700665453 /* UnrarKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnrarKit.h; sourceTree = "<group>"; };
+		96BF58BA1F3A487100BC24E1 /* UnrarKitMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnrarKitMacros.h; sourceTree = "<group>"; };
 		96DBF7F71A3F72800033B759 /* NSString+UnrarKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+UnrarKit.h"; path = "Categories/NSString+UnrarKit.h"; sourceTree = "<group>"; };
 		96DBF7F81A3F72800033B759 /* NSString+UnrarKit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSString+UnrarKit.mm"; path = "Categories/NSString+UnrarKit.mm"; sourceTree = "<group>"; };
 		96EA532E1B3B462D00F79DC6 /* iOSUnitTestHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSUnitTestHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -540,6 +543,7 @@
 				489CFA0F128B5169005DCC2A /* URKArchive.mm */,
 				F3FCD4691A3262E5003612BF /* URKFileInfo.h */,
 				F3FCD46A1A3262E5003612BF /* URKFileInfo.m */,
+				96BF58BA1F3A487100BC24E1 /* UnrarKitMacros.h */,
 			);
 			path = Classes;
 			sourceTree = SOURCE_ROOT;
@@ -803,6 +807,7 @@
 				9699FA411B3CBB1400B6D373 /* headers.hpp in Headers */,
 				9699FA421B3CBB1400B6D373 /* isnt.hpp in Headers */,
 				9699FA431B3CBB1400B6D373 /* list.hpp in Headers */,
+				96BF58BC1F3A487100BC24E1 /* UnrarKitMacros.h in Headers */,
 				9699FA441B3CBB1400B6D373 /* loclang.hpp in Headers */,
 				9699FA451B3CBB1400B6D373 /* log.hpp in Headers */,
 				9699FA461B3CBB1400B6D373 /* match.hpp in Headers */,
@@ -869,6 +874,7 @@
 				9699F9341B3CB4D000B6D373 /* headers.hpp in Headers */,
 				9699F9351B3CB4D000B6D373 /* isnt.hpp in Headers */,
 				9699F9361B3CB4D000B6D373 /* list.hpp in Headers */,
+				96BF58BB1F3A487100BC24E1 /* UnrarKitMacros.h in Headers */,
 				9699F9371B3CB4D000B6D373 /* loclang.hpp in Headers */,
 				9699F9381B3CB4D000B6D373 /* log.hpp in Headers */,
 				9699F9391B3CB4D000B6D373 /* match.hpp in Headers */,
@@ -1311,8 +1317,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CPLUSPLUSFLAGS = (
 					"-DSILENT",
@@ -1351,8 +1357,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CPLUSPLUSFLAGS = (
 					"-DSILENT",
 					"-DRARDLL",
@@ -1395,7 +1401,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
 				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
@@ -1428,7 +1433,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
 				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;


### PR DESCRIPTION
This PR addresses Issue #35, adding comprehensive logging. On later versions of macOS and iOS, it uses the new unified logging framework, and falls back to `NSLog` for older ones.