### PR TITLE
Fix warnings introduced by the -Weverything flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added enhanced support for multivolume archives (PRs #59, #38 - Thanks to [@aonez](https://github.com/aonez) for the idea and implementation!)
 * Added detailed logging using new unified logging framework. See [the readme](README.md) for more details (Issue #35)
 * Added localized details to returned `NSError` objects (Issue #45)
+* Moved `unrar` sources into a static library, and addressed a wide variety of warnings exposed by the `-Weverything` flag (Issue #56)
 * Switched to Travis Build Stages instead of the unofficial Travis-After-All (Issue #42)
 * Fixed warnings from Xcode 9 (Issue #51)
 * Removed iOS-specific targets, after allowing macOS framework and unit test bundles to be cross-platform (Issue #55)

--- a/Classes/Categories/NSString+UnrarKit.mm
+++ b/Classes/Categories/NSString+UnrarKit.mm
@@ -5,15 +5,9 @@
 //
 
 #import "NSString+UnrarKit.h"
+#import "UnrarKitMacros.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-align"
-#pragma clang diagnostic ignored "-Wextra-semi"
-#pragma clang diagnostic ignored "-Wold-style-cast"
-#pragma clang diagnostic ignored "-Wpadded"
-#pragma clang diagnostic ignored "-Wreserved-id-macro"
-#pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#pragma clang diagnostic ignored "-Wundef"
+RarHppIgnore
 #import "rar.hpp"
 #pragma clang diagnostic pop
 

--- a/Classes/Categories/NSString+UnrarKit.mm
+++ b/Classes/Categories/NSString+UnrarKit.mm
@@ -6,7 +6,16 @@
 
 #import "NSString+UnrarKit.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-align"
+#pragma clang diagnostic ignored "-Wextra-semi"
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wundef"
 #import "rar.hpp"
+#pragma clang diagnostic pop
 
 @implementation NSString (UnrarKit)
 

--- a/Classes/URKArchive.h
+++ b/Classes/URKArchive.h
@@ -129,12 +129,12 @@ extern NSString *URKErrorDomain;
 /**
  *  The URL of the archive
  */
-@property(nullable, weak, readonly) NSURL *fileURL;
+@property(nullable, weak, atomic, readonly) NSURL *fileURL;
 
 /**
  *  The filename of the archive
  */
-@property(nullable, weak, readonly) NSString *filename;
+@property(nullable, weak, atomic, readonly) NSString *filename;
 
 /**
  *  The password of the archive
@@ -144,17 +144,17 @@ extern NSString *URKErrorDomain;
 /**
  *  The total uncompressed size (in bytes) of all files in the archive. Returns nil on errors
  */
-@property(nullable, readonly) NSNumber *uncompressedSize;
+@property(nullable, atomic, readonly) NSNumber *uncompressedSize;
 
 /**
  *  The total compressed size (in bytes) of the archive. Returns nil on errors
  */
-@property(nullable, readonly) NSNumber *compressedSize;
+@property(nullable, atomic, readonly) NSNumber *compressedSize;
 
 /**
  *  True if the file is one volume of a multi-part archive
  */
-@property(readonly) BOOL hasMultipleVolumes;
+@property(atomic, readonly) BOOL hasMultipleVolumes;
 
 /**
  *  Can be used for progress reporting, but it's not necessary. You can also use

--- a/Classes/URKArchive.h
+++ b/Classes/URKArchive.h
@@ -6,10 +6,13 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
-#import "raros.hpp"
+#import "UnrarKitMacros.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wstrict-prototypes"
+RarosHppIgnore
+#import "raros.hpp"
+#pragma clang diagnostic pop
+
+DllHppIgnore
 #import "dll.hpp"
 #pragma clang diagnostic pop
 
@@ -117,15 +120,10 @@ extern NSString *URKErrorDomain;
  *  An Objective-C/Cocoa wrapper around the unrar library
  */
 @interface URKArchive : NSObject
-#if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_9_0 || MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_11
+// Minimum of iOS 9, macOS 10.11 SDKs
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED > 90000) || (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED > 101100)
 <NSProgressReporting>
 #endif
-{
-
-	HANDLE _rarFile;
-	struct RARHeaderDataEx *header;
-	struct RAROpenArchiveDataEx *flags;
-}
 
 
 /**

--- a/Classes/URKArchive.mm
+++ b/Classes/URKArchive.mm
@@ -28,7 +28,7 @@ static NSBundle *_resources = nil;
 
 @interface URKArchive ()
 
-- (instancetype)initWithFile:(NSURL *)fileURL password:(NSString*)password error:(NSError **)error
+- (instancetype)initWithFile:(NSURL *)fileURL password:(NSString*)password error:(NSError * __autoreleasing *)error
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_7_0 || MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_9
 NS_DESIGNATED_INITIALIZER
 #endif
@@ -100,32 +100,32 @@ NS_DESIGNATED_INITIALIZER
     return nil;
 }
 
-- (instancetype)initWithPath:(NSString *)filePath error:(NSError **)error
+- (instancetype)initWithPath:(NSString *)filePath error:(NSError * __autoreleasing *)error
 {
     return [self initWithFile:[NSURL fileURLWithPath:filePath] error:error];
 }
 
-- (instancetype)initWithURL:(NSURL *)fileURL error:(NSError **)error
+- (instancetype)initWithURL:(NSURL *)fileURL error:(NSError * __autoreleasing *)error
 {
     return [self initWithFile:fileURL error:error];
 }
 
-- (instancetype)initWithPath:(NSString *)filePath password:(NSString *)password error:(NSError **)error
+- (instancetype)initWithPath:(NSString *)filePath password:(NSString *)password error:(NSError * __autoreleasing *)error
 {
     return [self initWithFile:[NSURL fileURLWithPath:filePath] password:password error:error];
 }
 
-- (instancetype)initWithURL:(NSURL *)fileURL password:(NSString *)password error:(NSError **)error
+- (instancetype)initWithURL:(NSURL *)fileURL password:(NSString *)password error:(NSError * __autoreleasing *)error
 {
     return [self initWithFile:fileURL password:password error:error];
 }
 
-- (instancetype)initWithFile:(NSURL *)fileURL error:(NSError **)error
+- (instancetype)initWithFile:(NSURL *)fileURL error:(NSError * __autoreleasing *)error
 {
     return [self initWithFile:fileURL password:nil error:error];
 }
 
-- (instancetype)initWithFile:(NSURL *)fileURL password:(NSString*)password error:(NSError **)error
+- (instancetype)initWithFile:(NSURL *)fileURL password:(NSString*)password error:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("Init Archive");
 
@@ -349,7 +349,8 @@ NS_DESIGNATED_INITIALIZER
         return NO;
     }
 
-    return [URKArchive pathIsARAR:fileURL.path];
+    NSString *_Nonnull path = static_cast<NSString *_Nonnull>(fileURL.path);
+    return [URKArchive pathIsARAR:path];
 }
 
 
@@ -357,7 +358,7 @@ NS_DESIGNATED_INITIALIZER
 #pragma mark - Public Methods
 
 
-- (NSArray<NSString*> *)listFilenames:(NSError **)error
+- (NSArray<NSString*> *)listFilenames:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("Listing Filenames");
 
@@ -365,7 +366,7 @@ NS_DESIGNATED_INITIALIZER
     return [files valueForKey:@"filename"];
 }
 
-- (NSArray<URKFileInfo*> *)listFileInfo:(NSError **)error
+- (NSArray<URKFileInfo*> *)listFileInfo:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("Listing File Info");
 
@@ -409,7 +410,7 @@ NS_DESIGNATED_INITIALIZER
     return [NSArray arrayWithArray:fileInfos];
 }
 
-- (nullable NSArray<NSURL*> *)listVolumeURLs:(NSError **)error
+- (nullable NSArray<NSURL*> *)listVolumeURLs:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("Listing Volume URLs");
 
@@ -438,7 +439,7 @@ NS_DESIGNATED_INITIALIZER
 
 - (BOOL)extractFilesTo:(NSString *)filePath
              overwrite:(BOOL)overwrite
-                 error:(NSError **)error
+                 error:(NSError * __autoreleasing *)error
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -452,7 +453,7 @@ NS_DESIGNATED_INITIALIZER
 - (BOOL)extractFilesTo:(NSString *)filePath
              overwrite:(BOOL)overwrite
               progress:(void (^)(URKFileInfo *currentFile, CGFloat percentArchiveDecompressed))progressBlock
-                 error:(NSError **)error
+                 error:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("Extracting Files to Directory");
 
@@ -524,7 +525,12 @@ NS_DESIGNATED_INITIALIZER
             progress.completedUnitCount += fileInfo.uncompressedSize;
             
             if (progressBlock) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdouble-promotion"
+                // I would change the signature of this block, but it's been deprecated already,
+                // so it'll just get dropped eventually, and it made sense to silence the warning
                 progressBlock(fileInfo, bytesDecompressed / totalSize.floatValue);
+#pragma clang diagnostic pop
             }
 
             bytesDecompressed += fileInfo.uncompressedSize;
@@ -547,7 +553,7 @@ NS_DESIGNATED_INITIALIZER
 }
 
 - (NSData *)extractData:(URKFileInfo *)fileInfo
-                  error:(NSError **)error
+                  error:(NSError * __autoreleasing *)error
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -557,13 +563,13 @@ NS_DESIGNATED_INITIALIZER
 
 - (NSData *)extractData:(URKFileInfo *)fileInfo
                progress:(void (^)(CGFloat percentDecompressed))progressBlock
-                  error:(NSError **)error
+                  error:(NSError * __autoreleasing *)error
 {
     return [self extractDataFromFile:fileInfo.filename progress:progressBlock error:error];
 }
 
 - (NSData *)extractDataFromFile:(NSString *)filePath
-                          error:(NSError **)error
+                          error:(NSError * __autoreleasing *)error
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -573,7 +579,7 @@ NS_DESIGNATED_INITIALIZER
 
 - (NSData *)extractDataFromFile:(NSString *)filePath
                        progress:(void (^)(CGFloat percentDecompressed))progressBlock
-                          error:(NSError **)error
+                          error:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("Extracting Data from File");
     
@@ -683,7 +689,7 @@ NS_DESIGNATED_INITIALIZER
 }
 
 - (BOOL)performOnFilesInArchive:(void(^)(URKFileInfo *fileInfo, BOOL *stop))action
-                          error:(NSError **)error
+                          error:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("Performing Action on Each File");
 
@@ -733,7 +739,7 @@ NS_DESIGNATED_INITIALIZER
 }
 
 - (BOOL)performOnDataInArchive:(void (^)(URKFileInfo *, NSData *, BOOL *))action
-                         error:(NSError **)error
+                         error:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("Performing Action on Each File's Data");
 
@@ -823,7 +829,7 @@ NS_DESIGNATED_INITIALIZER
 }
 
 - (BOOL)extractBufferedDataFromFile:(NSString *)filePath
-                              error:(NSError **)error
+                              error:(NSError * __autoreleasing *)error
                              action:(void(^)(NSData *dataChunk, CGFloat percentDecompressed))action
 {
     URKCreateActivity("Extracting Buffered Data");
@@ -866,7 +872,7 @@ NS_DESIGNATED_INITIALIZER
             }
         }
         
-        CGFloat totalBytes = fileInfo.uncompressedSize;
+        long long totalBytes = fileInfo.uncompressedSize;
         progress.totalUnitCount = totalBytes;
         
         if (RHCode != ERAR_SUCCESS) {
@@ -885,7 +891,7 @@ NS_DESIGNATED_INITIALIZER
         __block long long bytesRead = 0;
 
         // Repeating the argument instead of using positional specifiers, because they don't work with the {} formatters
-        URKLogDebug("Uncompressed size: %{iec-bytes}lld (%lld bytes) in file", (long long)totalBytes, (long long)totalBytes);
+        URKLogDebug("Uncompressed size: %{iec-bytes}lld (%lld bytes) in file", totalBytes, totalBytes);
 
         RARSetCallback(welf.rarFile, BufferedReadCallbackProc, (long)(__bridge void *) self);
         self.bufferedReadBlock = ^BOOL(NSData *dataChunk) {
@@ -897,7 +903,7 @@ NS_DESIGNATED_INITIALIZER
             bytesRead += dataChunk.length;
             progress.completedUnitCount += dataChunk.length;
 
-            CGFloat progressPercent = bytesRead / totalBytes;
+            CGFloat progressPercent = bytesRead / static_cast<CGFloat>(totalBytes);
             URKLogDebug("Read data chunk of size %lu (%.3f%% complete). Calling handler...", (unsigned long)dataChunk.length, progressPercent * 100);
             action(dataChunk, progressPercent);
             return YES;
@@ -1076,7 +1082,7 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
 
 - (BOOL)performActionWithArchiveOpen:(void(^)(NSError **innerError))action
                               inMode:(NSInteger)mode
-                               error:(NSError **)error
+                               error:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("-performActionWithArchiveOpen:inMode:error:");
 
@@ -1126,7 +1132,7 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
     }
 }
 
-- (BOOL)_unrarOpenFile:(NSString *)rarFile inMode:(NSInteger)mode withPassword:(NSString *)aPassword error:(NSError **)error
+- (BOOL)_unrarOpenFile:(NSString *)rarFile inMode:(NSInteger)mode withPassword:(NSString *)aPassword error:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("-_unrarOpenFile:inMode:withPassword:error:");
 
@@ -1190,7 +1196,7 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
     return YES;
 }
 
-- (NSString *)errorNameForErrorCode:(NSInteger)errorCode detail:(NSString **)errorDetail
+- (NSString *)errorNameForErrorCode:(NSInteger)errorCode detail:(NSString * __autoreleasing *)errorDetail
 {
     NSAssert(errorDetail != NULL, @"errorDetail out parameter not given");
     
@@ -1282,7 +1288,7 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
     return errorName;
 }
 
-- (BOOL)assignError:(NSError **)error code:(NSInteger)errorCode errorName:(NSString **)outErrorName
+- (BOOL)assignError:(NSError * __autoreleasing *)error code:(NSInteger)errorCode errorName:(NSString * __autoreleasing *)outErrorName
 {
     if (error) {
         NSAssert(outErrorName, @"An out variable for errorName must be provided");
@@ -1307,7 +1313,7 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
     return NO;
 }
 
-- (BOOL)headerContainsErrors:(NSError **)error
+- (BOOL)headerContainsErrors:(NSError * __autoreleasing *)error
 {
     URKCreateActivity("-headerContainsErrors:");
 

--- a/Classes/URKArchive.mm
+++ b/Classes/URKArchive.mm
@@ -1329,7 +1329,7 @@ int CALLBACK BufferedReadCallbackProc(UINT msg, long UserData, long P1, long P2)
     return NO;
 }
 
-- (NSProgress *)beginProgressOperation:(NSUInteger)totalUnitCount
+- (NSProgress *)beginProgressOperation:(unsigned long long)totalUnitCount
 {
     URKCreateActivity("-beginProgressOperation:");
     

--- a/Classes/URKFileInfo.h
+++ b/Classes/URKFileInfo.h
@@ -4,10 +4,13 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "raros.hpp"
+#import "UnrarKitMacros.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wstrict-prototypes"
+RarosHppIgnore
+#import "raros.hpp"
+#pragma clang diagnostic pop
+
+DllHppIgnore
 #import "dll.hpp"
 #pragma clang diagnostic pop
 

--- a/Classes/UnrarKitMacros.h
+++ b/Classes/UnrarKitMacros.h
@@ -12,6 +12,28 @@
 //#import "Availability.h"
 //#import "AvailabilityInternal.h"
 
+#define _stringify(a) #a
+
+#define RarHppIgnore \
+_Pragma( _stringify( clang diagnostic push ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wcast-align" ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wextra-semi" ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wold-style-cast" ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wpadded" ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wreserved-id-macro" ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wshorten-64-to-32" ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wundef" ) )
+
+#define DllHppIgnore \
+_Pragma( _stringify( clang diagnostic push ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wreserved-id-macro" ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wstrict-prototypes" ) ) \
+
+#define RarosHppIgnore \
+_Pragma( _stringify( clang diagnostic push ) ) \
+_Pragma( _stringify( clang diagnostic ignored "-Wreserved-id-macro" ) ) \
+
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundef"
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
@@ -54,7 +76,6 @@ os_activity_scope(activity);
 #define _removeLogFormatTokens(format) [[@format \
     stringByReplacingOccurrencesOfString:@"{public}" withString:@""] \
     stringByReplacingOccurrencesOfString:@"{iec-bytes}" withString:@""]
-#define _stringify(a) #a
 #define _nsLogWithoutWarnings(format, ...) \
 _Pragma( _stringify( clang diagnostic push ) ) \
 _Pragma( _stringify( clang diagnostic ignored "-Wformat-nonliteral" ) ) \
@@ -72,9 +93,9 @@ _Pragma( _stringify( clang diagnostic pop ) )
 // No-op, as no equivalent to Activities exists
 #define URKCreateActivity(name) (void)0
 
-#endif
-
 
 #pragma clang diagnostic pop
+
+#endif // UNIFIED_LOGGING_SUPPORTED
 
 #endif /* UnrarKitMacros_h */

--- a/UnrarKit.xcodeproj/project.pbxproj
+++ b/UnrarKit.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		7AC29ACB1F83C3E700DA4DE6 /* libunrar.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7AC29A5D1F83C08200DA4DE6 /* libunrar.a */; };
 		7AC29ACD1F83DB0400DA4DE6 /* dll.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1A18DB722E00B5651B /* dll.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		7AC29ACE1F83DB1000DA4DE6 /* raros.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4E18DB722E00B5651B /* raros.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AC29AD01F850A6A00DA4DE6 /* UnrarKitMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 96BF58BA1F3A487100BC24E1 /* UnrarKitMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		964C8AC718D28EE000AD7321 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 964C8AC518D28EE000AD7321 /* InfoPlist.strings */; };
 		9660D7AF1A3F4FF90059AC1E /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9660D7AE1A3F4FF90059AC1E /* libz.dylib */; };
 		967872741E460FA70048A54C /* ListVolumesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 967872731E460FA70048A54C /* ListVolumesTests.m */; };
@@ -729,6 +730,7 @@
 				9699F91D1B3CB4D000B6D373 /* URKArchive.h in Headers */,
 				9699F91E1B3CB4D000B6D373 /* URKFileInfo.h in Headers */,
 				9699F91F1B3CB4D000B6D373 /* UnrarKit.h in Headers */,
+				7AC29AD01F850A6A00DA4DE6 /* UnrarKitMacros.h in Headers */,
 				7AC29ACD1F83DB0400DA4DE6 /* dll.hpp in Headers */,
 				7AC29ACE1F83DB1000DA4DE6 /* raros.hpp in Headers */,
 			);

--- a/UnrarKit.xcodeproj/project.pbxproj
+++ b/UnrarKit.xcodeproj/project.pbxproj
@@ -1050,7 +1050,6 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_THUMB_SUPPORT = NO;
@@ -1097,7 +1096,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
@@ -1342,7 +1340,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_VERSION = A;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1367,6 +1364,8 @@
 					"-Weverything",
 					"-Wno-auto-import",
 					"-Wno-objc-missing-property-synthesis",
+					"-Wno-variadic-macros",
+					"-Wno-old-style-cast",
 				);
 			};
 			name = Debug;
@@ -1395,7 +1394,6 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_VERSION = A;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -1415,6 +1413,8 @@
 					"-Weverything",
 					"-Wno-auto-import",
 					"-Wno-objc-missing-property-synthesis",
+					"-Wno-variadic-macros",
+					"-Wno-old-style-cast",
 				);
 			};
 			name = Release;

--- a/UnrarKit.xcodeproj/project.pbxproj
+++ b/UnrarKit.xcodeproj/project.pbxproj
@@ -1363,10 +1363,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-                WARNING_CFLAGS = (
-                    "-Wno-shorten-64-to-32",
-                    "-Wdocumentation",
-                );
+				WARNING_CFLAGS = (
+					"-Weverything",
+					"-Wno-auto-import",
+					"-Wno-objc-missing-property-synthesis",
+				);
 			};
 			name = Debug;
 		};
@@ -1410,10 +1411,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				VALIDATE_PRODUCT = YES;
-                WARNING_CFLAGS = (
-                    "-Wno-shorten-64-to-32",
-                    "-Wdocumentation",
-                );
+				WARNING_CFLAGS = (
+					"-Weverything",
+					"-Wno-auto-import",
+					"-Wno-objc-missing-property-synthesis",
+				);
 			};
 			name = Release;
 		};

--- a/UnrarKit.xcodeproj/project.pbxproj
+++ b/UnrarKit.xcodeproj/project.pbxproj
@@ -116,68 +116,15 @@
 		7AC29AC81F83C36900DA4DE6 /* unpack.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7B18DB722E00B5651B /* unpack.hpp */; };
 		7AC29AC91F83C36900DA4DE6 /* version.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F8118DB722F00B5651B /* version.hpp */; };
 		7AC29ACA1F83C36900DA4DE6 /* volume.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F8318DB722F00B5651B /* volume.hpp */; };
+		7AC29ACB1F83C3E700DA4DE6 /* libunrar.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7AC29A5D1F83C08200DA4DE6 /* libunrar.a */; };
+		7AC29ACD1F83DB0400DA4DE6 /* dll.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1A18DB722E00B5651B /* dll.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AC29ACE1F83DB1000DA4DE6 /* raros.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4E18DB722E00B5651B /* raros.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		964C8AC718D28EE000AD7321 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 964C8AC518D28EE000AD7321 /* InfoPlist.strings */; };
 		9660D7AF1A3F4FF90059AC1E /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9660D7AE1A3F4FF90059AC1E /* libz.dylib */; };
 		967872741E460FA70048A54C /* ListVolumesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 967872731E460FA70048A54C /* ListVolumesTests.m */; };
 		9699F91D1B3CB4D000B6D373 /* URKArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 489CFA0E128B5169005DCC2A /* URKArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9699F91E1B3CB4D000B6D373 /* URKFileInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = F3FCD4691A3262E5003612BF /* URKFileInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9699F91F1B3CB4D000B6D373 /* UnrarKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 969F17361A60297700665453 /* UnrarKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9699F9201B3CB4D000B6D373 /* archive.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F0918DB722E00B5651B /* archive.hpp */; };
-		9699F9211B3CB4D000B6D373 /* array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F0B18DB722E00B5651B /* array.hpp */; };
-		9699F9221B3CB4D000B6D373 /* cmddata.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F0E18DB722E00B5651B /* cmddata.hpp */; };
-		9699F9231B3CB4D000B6D373 /* coder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1018DB722E00B5651B /* coder.hpp */; };
-		9699F9241B3CB4D000B6D373 /* compress.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1118DB722E00B5651B /* compress.hpp */; };
-		9699F9251B3CB4D000B6D373 /* consio.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1318DB722E00B5651B /* consio.hpp */; };
-		9699F9261B3CB4D000B6D373 /* crc.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1518DB722E00B5651B /* crc.hpp */; };
-		9699F9271B3CB4D000B6D373 /* crypt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1718DB722E00B5651B /* crypt.hpp */; };
-		9699F9281B3CB4D000B6D373 /* dll.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1A18DB722E00B5651B /* dll.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
-		9699F9291B3CB4D000B6D373 /* encname.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1D18DB722E00B5651B /* encname.hpp */; };
-		9699F92A1B3CB4D000B6D373 /* errhnd.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1F18DB722E00B5651B /* errhnd.hpp */; };
-		9699F92B1B3CB4D000B6D373 /* extinfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2118DB722E00B5651B /* extinfo.hpp */; };
-		9699F92C1B3CB4D000B6D373 /* extract.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2318DB722E00B5651B /* extract.hpp */; };
-		9699F92D1B3CB4D000B6D373 /* filcreat.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2518DB722E00B5651B /* filcreat.hpp */; };
-		9699F92E1B3CB4D000B6D373 /* file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2718DB722E00B5651B /* file.hpp */; };
-		9699F92F1B3CB4D000B6D373 /* filefn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2918DB722E00B5651B /* filefn.hpp */; };
-		9699F9301B3CB4D000B6D373 /* filestr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2B18DB722E00B5651B /* filestr.hpp */; };
-		9699F9311B3CB4D000B6D373 /* find.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2D18DB722E00B5651B /* find.hpp */; };
-		9699F9321B3CB4D000B6D373 /* getbits.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2F18DB722E00B5651B /* getbits.hpp */; };
-		9699F9331B3CB4D000B6D373 /* global.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3118DB722E00B5651B /* global.hpp */; };
-		9699F9341B3CB4D000B6D373 /* headers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3218DB722E00B5651B /* headers.hpp */; };
-		9699F9351B3CB4D000B6D373 /* isnt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3418DB722E00B5651B /* isnt.hpp */; };
-		9699F9361B3CB4D000B6D373 /* list.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3718DB722E00B5651B /* list.hpp */; };
-		9699F9371B3CB4D000B6D373 /* loclang.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3818DB722E00B5651B /* loclang.hpp */; };
-		9699F9381B3CB4D000B6D373 /* log.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3A18DB722E00B5651B /* log.hpp */; };
-		9699F9391B3CB4D000B6D373 /* match.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4018DB722E00B5651B /* match.hpp */; };
-		9699F93A1B3CB4D000B6D373 /* model.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4218DB722E00B5651B /* model.hpp */; };
-		9699F93B1B3CB4D000B6D373 /* options.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4518DB722E00B5651B /* options.hpp */; };
-		9699F93C1B3CB4D000B6D373 /* os.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4618DB722E00B5651B /* os.hpp */; };
-		9699F93D1B3CB4D000B6D373 /* pathfn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4918DB722E00B5651B /* pathfn.hpp */; };
-		9699F93E1B3CB4D000B6D373 /* rar.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4B18DB722E00B5651B /* rar.hpp */; };
-		9699F93F1B3CB4D000B6D373 /* rardefs.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4C18DB722E00B5651B /* rardefs.hpp */; };
-		9699F9401B3CB4D000B6D373 /* rarlang.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4D18DB722E00B5651B /* rarlang.hpp */; };
-		9699F9411B3CB4D000B6D373 /* raros.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4E18DB722E00B5651B /* raros.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
-		9699F9421B3CB4D000B6D373 /* rartypes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5018DB722E00B5651B /* rartypes.hpp */; };
-		9699F9431B3CB4D000B6D373 /* rarvm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5218DB722E00B5651B /* rarvm.hpp */; };
-		9699F9441B3CB4D000B6D373 /* rawread.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5518DB722E00B5651B /* rawread.hpp */; };
-		9699F9451B3CB4D000B6D373 /* rdwrfn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5718DB722E00B5651B /* rdwrfn.hpp */; };
-		9699F9461B3CB4D000B6D373 /* recvol.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5A18DB722E00B5651B /* recvol.hpp */; };
-		9699F9471B3CB4D000B6D373 /* resource.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5C18DB722E00B5651B /* resource.hpp */; };
-		9699F9481B3CB4D000B6D373 /* rijndael.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5E18DB722E00B5651B /* rijndael.hpp */; };
-		9699F9491B3CB4D000B6D373 /* rs.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6018DB722E00B5651B /* rs.hpp */; };
-		9699F94B1B3CB4D000B6D373 /* savepos.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6218DB722E00B5651B /* savepos.hpp */; };
-		9699F94C1B3CB4D000B6D373 /* scantree.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6418DB722E00B5651B /* scantree.hpp */; };
-		9699F94D1B3CB4D000B6D373 /* secpassword.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6618DB722E00B5651B /* secpassword.hpp */; };
-		9699F94E1B3CB4D000B6D373 /* sha1.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6818DB722E00B5651B /* sha1.hpp */; };
-		9699F94F1B3CB4D000B6D373 /* smallfn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6A18DB722E00B5651B /* smallfn.hpp */; };
-		9699F9501B3CB4D000B6D373 /* strfn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6C18DB722E00B5651B /* strfn.hpp */; };
-		9699F9511B3CB4D000B6D373 /* strlist.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6E18DB722E00B5651B /* strlist.hpp */; };
-		9699F9521B3CB4D000B6D373 /* suballoc.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7018DB722E00B5651B /* suballoc.hpp */; };
-		9699F9531B3CB4D000B6D373 /* system.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7218DB722E00B5651B /* system.hpp */; };
-		9699F9541B3CB4D000B6D373 /* timefn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7418DB722E00B5651B /* timefn.hpp */; };
-		9699F9561B3CB4D000B6D373 /* unicode.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7818DB722E00B5651B /* unicode.hpp */; };
-		9699F9571B3CB4D000B6D373 /* unpack.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7B18DB722E00B5651B /* unpack.hpp */; };
-		9699F9581B3CB4D000B6D373 /* version.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F8118DB722F00B5651B /* version.hpp */; };
-		9699F9591B3CB4D000B6D373 /* volume.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F8318DB722F00B5651B /* volume.hpp */; };
 		9699FA6A1B3CE95D00B6D373 /* UnrarKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96EA535B1B3CB04300F79DC6 /* UnrarKit.framework */; };
 		9699FA891B3D9B5700B6D373 /* URKArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 964C8AC818D28EE000AD7321 /* URKArchiveTests.m */; };
 		9699FA8A1B3D9B6F00B6D373 /* URKArchiveTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 964547D11B384F7D00202B28 /* URKArchiveTestCase.m */; };
@@ -185,7 +132,6 @@
 		9699FA8C1B3D9B6F00B6D373 /* IsPasswordProtectedTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F450761B38552200679597 /* IsPasswordProtectedTests.m */; };
 		9699FA8D1B3D9B6F00B6D373 /* ListFilenamesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F450781B385AF800679597 /* ListFilenamesTests.m */; };
 		9699FA8E1B3D9B6F00B6D373 /* ValidatePasswordTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F450741B38527100679597 /* ValidatePasswordTests.m */; };
-		96BF58BB1F3A487100BC24E1 /* UnrarKitMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 96BF58BA1F3A487100BC24E1 /* UnrarKitMacros.h */; };
 		96A043DE1E4CC8D500BD7013 /* FirstVolumeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A043DD1E4CC8D500BD7013 /* FirstVolumeTests.m */; };
 		96A043E01E4D232F00BD7013 /* HasMultipleVolumesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A043DF1E4D232F00BD7013 /* HasMultipleVolumesTests.m */; };
 		96E5D345198B333200A74340 /* Test Data in Resources */ = {isa = PBXBuildFile; fileRef = 964C8AD018D28F1600AD7321 /* Test Data */; };
@@ -431,9 +377,9 @@
 		96853F8418DB722F00B5651B /* win32acl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = win32acl.cpp; sourceTree = "<group>"; };
 		96853F8518DB722F00B5651B /* win32stm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = win32stm.cpp; sourceTree = "<group>"; };
 		969F17361A60297700665453 /* UnrarKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnrarKit.h; sourceTree = "<group>"; };
-		96BF58BA1F3A487100BC24E1 /* UnrarKitMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnrarKitMacros.h; sourceTree = "<group>"; };
 		96A043DD1E4CC8D500BD7013 /* FirstVolumeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirstVolumeTests.m; sourceTree = "<group>"; };
 		96A043DF1E4D232F00BD7013 /* HasMultipleVolumesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HasMultipleVolumesTests.m; sourceTree = "<group>"; };
+		96BF58BA1F3A487100BC24E1 /* UnrarKitMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnrarKitMacros.h; sourceTree = "<group>"; };
 		96DBF7F71A3F72800033B759 /* NSString+UnrarKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+UnrarKit.h"; path = "Categories/NSString+UnrarKit.h"; sourceTree = "<group>"; };
 		96DBF7F81A3F72800033B759 /* NSString+UnrarKit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSString+UnrarKit.mm"; path = "Categories/NSString+UnrarKit.mm"; sourceTree = "<group>"; };
 		96EA53311B3B462D00F79DC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -477,6 +423,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7AC29ACB1F83C3E700DA4DE6 /* libunrar.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -832,63 +779,8 @@
 				9699F91D1B3CB4D000B6D373 /* URKArchive.h in Headers */,
 				9699F91E1B3CB4D000B6D373 /* URKFileInfo.h in Headers */,
 				9699F91F1B3CB4D000B6D373 /* UnrarKit.h in Headers */,
-				9699F9281B3CB4D000B6D373 /* dll.hpp in Headers */,
-				9699F9411B3CB4D000B6D373 /* raros.hpp in Headers */,
-				9699F9201B3CB4D000B6D373 /* archive.hpp in Headers */,
-				9699F9211B3CB4D000B6D373 /* array.hpp in Headers */,
-				9699F9221B3CB4D000B6D373 /* cmddata.hpp in Headers */,
-				9699F9231B3CB4D000B6D373 /* coder.hpp in Headers */,
-				9699F9241B3CB4D000B6D373 /* compress.hpp in Headers */,
-				9699F9251B3CB4D000B6D373 /* consio.hpp in Headers */,
-				9699F9261B3CB4D000B6D373 /* crc.hpp in Headers */,
-				9699F9271B3CB4D000B6D373 /* crypt.hpp in Headers */,
-				9699F9291B3CB4D000B6D373 /* encname.hpp in Headers */,
-				9699F92A1B3CB4D000B6D373 /* errhnd.hpp in Headers */,
-				9699F92B1B3CB4D000B6D373 /* extinfo.hpp in Headers */,
-				9699F92C1B3CB4D000B6D373 /* extract.hpp in Headers */,
-				9699F92D1B3CB4D000B6D373 /* filcreat.hpp in Headers */,
-				9699F92E1B3CB4D000B6D373 /* file.hpp in Headers */,
-				9699F92F1B3CB4D000B6D373 /* filefn.hpp in Headers */,
-				9699F9301B3CB4D000B6D373 /* filestr.hpp in Headers */,
-				9699F9311B3CB4D000B6D373 /* find.hpp in Headers */,
-				9699F9321B3CB4D000B6D373 /* getbits.hpp in Headers */,
-				9699F9331B3CB4D000B6D373 /* global.hpp in Headers */,
-				9699F9341B3CB4D000B6D373 /* headers.hpp in Headers */,
-				9699F9351B3CB4D000B6D373 /* isnt.hpp in Headers */,
-				9699F9361B3CB4D000B6D373 /* list.hpp in Headers */,
-				96BF58BB1F3A487100BC24E1 /* UnrarKitMacros.h in Headers */,
-				9699F9371B3CB4D000B6D373 /* loclang.hpp in Headers */,
-				9699F9381B3CB4D000B6D373 /* log.hpp in Headers */,
-				9699F9391B3CB4D000B6D373 /* match.hpp in Headers */,
-				9699F93A1B3CB4D000B6D373 /* model.hpp in Headers */,
-				9699F93B1B3CB4D000B6D373 /* options.hpp in Headers */,
-				9699F93C1B3CB4D000B6D373 /* os.hpp in Headers */,
-				9699F93D1B3CB4D000B6D373 /* pathfn.hpp in Headers */,
-				9699F93E1B3CB4D000B6D373 /* rar.hpp in Headers */,
-				9699F93F1B3CB4D000B6D373 /* rardefs.hpp in Headers */,
-				9699F9401B3CB4D000B6D373 /* rarlang.hpp in Headers */,
-				9699F9421B3CB4D000B6D373 /* rartypes.hpp in Headers */,
-				9699F9431B3CB4D000B6D373 /* rarvm.hpp in Headers */,
-				9699F9441B3CB4D000B6D373 /* rawread.hpp in Headers */,
-				9699F9451B3CB4D000B6D373 /* rdwrfn.hpp in Headers */,
-				9699F9461B3CB4D000B6D373 /* recvol.hpp in Headers */,
-				9699F9471B3CB4D000B6D373 /* resource.hpp in Headers */,
-				9699F9481B3CB4D000B6D373 /* rijndael.hpp in Headers */,
-				9699F9491B3CB4D000B6D373 /* rs.hpp in Headers */,
-				9699F94B1B3CB4D000B6D373 /* savepos.hpp in Headers */,
-				9699F94C1B3CB4D000B6D373 /* scantree.hpp in Headers */,
-				9699F94D1B3CB4D000B6D373 /* secpassword.hpp in Headers */,
-				9699F94E1B3CB4D000B6D373 /* sha1.hpp in Headers */,
-				9699F94F1B3CB4D000B6D373 /* smallfn.hpp in Headers */,
-				9699F9501B3CB4D000B6D373 /* strfn.hpp in Headers */,
-				9699F9511B3CB4D000B6D373 /* strlist.hpp in Headers */,
-				9699F9521B3CB4D000B6D373 /* suballoc.hpp in Headers */,
-				9699F9531B3CB4D000B6D373 /* system.hpp in Headers */,
-				9699F9541B3CB4D000B6D373 /* timefn.hpp in Headers */,
-				9699F9561B3CB4D000B6D373 /* unicode.hpp in Headers */,
-				9699F9571B3CB4D000B6D373 /* unpack.hpp in Headers */,
-				9699F9581B3CB4D000B6D373 /* version.hpp in Headers */,
-				9699F9591B3CB4D000B6D373 /* volume.hpp in Headers */,
+				7AC29ACD1F83DB0400DA4DE6 /* dll.hpp in Headers */,
+				7AC29ACE1F83DB1000DA4DE6 /* raros.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1402,6 +1294,7 @@
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
@@ -1418,8 +1311,13 @@
 					"$(inherited)",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = (
+					"-Xanalyzer",
+					"-analyzer-disable-all-checks",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1432,6 +1330,7 @@
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
@@ -1443,9 +1342,15 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				EXECUTABLE_PREFIX = lib;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"-Xanalyzer",
+					"-analyzer-disable-all-checks",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/UnrarKit.xcodeproj/project.pbxproj
+++ b/UnrarKit.xcodeproj/project.pbxproj
@@ -135,58 +135,8 @@
 		96A043DE1E4CC8D500BD7013 /* FirstVolumeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A043DD1E4CC8D500BD7013 /* FirstVolumeTests.m */; };
 		96A043E01E4D232F00BD7013 /* HasMultipleVolumesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A043DF1E4D232F00BD7013 /* HasMultipleVolumesTests.m */; };
 		96E5D345198B333200A74340 /* Test Data in Resources */ = {isa = PBXBuildFile; fileRef = 964C8AD018D28F1600AD7321 /* Test Data */; };
-		96EA53781B3CB2C700F79DC6 /* rar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F4A18DB722E00B5651B /* rar.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53791B3CB2C700F79DC6 /* strlist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6D18DB722E00B5651B /* strlist.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		96EA537A1B3CB2C700F79DC6 /* strfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6B18DB722E00B5651B /* strfn.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-logical-op-parentheses"; }; };
-		96EA537B1B3CB2C700F79DC6 /* pathfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F4818DB722E00B5651B /* pathfn.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		96EA537C1B3CB2C700F79DC6 /* smallfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6918DB722E00B5651B /* smallfn.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA537D1B3CB2C700F79DC6 /* global.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F3018DB722E00B5651B /* global.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		96EA537E1B3CB2C700F79DC6 /* URKFileInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = F3FCD46A1A3262E5003612BF /* URKFileInfo.m */; };
-		96EA537F1B3CB2C700F79DC6 /* file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2618DB722E00B5651B /* file.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks -Wno-unused-variable"; }; };
-		96EA53801B3CB2C700F79DC6 /* filefn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2818DB722E00B5651B /* filefn.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53811B3CB2C700F79DC6 /* filcreat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2418DB722E00B5651B /* filcreat.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53821B3CB2C700F79DC6 /* archive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F0818DB722E00B5651B /* archive.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-logical-op-parentheses -Wno-parentheses -Wno-unused-function"; }; };
-		96EA53831B3CB2C700F79DC6 /* arcread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F0A18DB722E00B5651B /* arcread.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks -Wno-switch -Wno-conditional-uninitialized"; }; };
-		96EA53841B3CB2C700F79DC6 /* unicode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F7718DB722E00B5651B /* unicode.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-shorten-64-to-32 -Wno-parentheses -Wno-unused-function"; }; };
-		96EA53851B3CB2C700F79DC6 /* system.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F7118DB722E00B5651B /* system.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53861B3CB2C700F79DC6 /* isnt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F3318DB722E00B5651B /* isnt.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53871B3CB2C700F79DC6 /* crypt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1618DB722E00B5651B /* crypt.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-logical-op-parentheses -Wno-switch"; }; };
-		96EA53881B3CB2C700F79DC6 /* crc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1418DB722E00B5651B /* crc.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53891B3CB2C700F79DC6 /* rawread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5418DB722E00B5651B /* rawread.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Xanalyzer -analyzer-disable-all-checks -Wno-unused-command-line-argument"; }; };
-		96EA538A1B3CB2C700F79DC6 /* encname.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1C18DB722E00B5651B /* encname.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA538B1B3CB2C700F79DC6 /* resource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5B18DB722E00B5651B /* resource.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA538C1B3CB2C700F79DC6 /* match.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F3F18DB722E00B5651B /* match.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-parentheses"; }; };
-		96EA538D1B3CB2C700F79DC6 /* timefn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F7318DB722E00B5651B /* timefn.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA538E1B3CB2C700F79DC6 /* rdwrfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5618DB722E00B5651B /* rdwrfn.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-logical-op-parentheses"; }; };
-		96EA538F1B3CB2C700F79DC6 /* consio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1218DB722E00B5651B /* consio.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-unused-variable"; }; };
-		96EA53901B3CB2C700F79DC6 /* options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F4418DB722E00B5651B /* options.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53911B3CB2C700F79DC6 /* errhnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1E18DB722E00B5651B /* errhnd.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53921B3CB2C700F79DC6 /* rarvm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5118DB722E00B5651B /* rarvm.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks -Wno-switch"; }; };
-		96EA53931B3CB2C700F79DC6 /* secpassword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6518DB722E00B5651B /* secpassword.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53941B3CB2C700F79DC6 /* rijndael.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5D18DB722E00B5651B /* rijndael.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks -Wno-conditional-uninitialized"; }; };
-		96EA53951B3CB2C700F79DC6 /* getbits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2E18DB722E00B5651B /* getbits.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		96EA53961B3CB2C700F79DC6 /* NSString+UnrarKit.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96DBF7F81A3F72800033B759 /* NSString+UnrarKit.mm */; };
-		96EA53971B3CB2C700F79DC6 /* sha1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6718DB722E00B5651B /* sha1.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53981B3CB2C700F79DC6 /* sha256.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FCF19ED8BB200DAF8F1 /* sha256.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53991B3CB2C700F79DC6 /* blake2s.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FB419ED8A8200DAF8F1 /* blake2s.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA539A1B3CB2C700F79DC6 /* hash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FC419ED8B0400DAF8F1 /* hash.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-logical-op-parentheses"; }; };
-		96EA539B1B3CB2C700F79DC6 /* extinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2018DB722E00B5651B /* extinfo.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-shorten-64-to-32"; }; };
-		96EA539C1B3CB2C700F79DC6 /* extract.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2218DB722E00B5651B /* extract.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-parentheses"; }; };
-		96EA539D1B3CB2C700F79DC6 /* volume.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F8218DB722F00B5651B /* volume.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-logical-op-parentheses"; }; };
-		96EA539E1B3CB2C700F79DC6 /* list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F3618DB722E00B5651B /* list.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-parentheses -Wno-switch -Wno-unused-function"; }; };
-		96EA539F1B3CB2C700F79DC6 /* find.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2C18DB722E00B5651B /* find.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53A01B3CB2C700F79DC6 /* unpack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F7A18DB722E00B5651B /* unpack.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-parentheses -Wno-conditional-uninitialized -Wno-unused-variable -Xanalyzer -analyzer-disable-all-checks -Wno-unused-command-line-argument"; }; };
-		96EA53A11B3CB2C700F79DC6 /* headers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FC619ED8B1F00DAF8F1 /* headers.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Xanalyzer -analyzer-disable-all-checks -Wno-unused-command-line-argument"; }; };
-		96EA53A21B3CB2C700F79DC6 /* threadpool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FD219ED8C6100DAF8F1 /* threadpool.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53A31B3CB2C700F79DC6 /* rs16.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FCD19ED8B9700DAF8F1 /* rs16.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-unused-variable"; }; };
-		96EA53A41B3CB2C700F79DC6 /* cmddata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F0D18DB722E00B5651B /* cmddata.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-parentheses -Wno-shorten-64-to-32"; }; };
-		96EA53A51B3CB2C700F79DC6 /* ui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FD419ED8C8000DAF8F1 /* ui.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		96EA53A61B3CB2C700F79DC6 /* filestr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2A18DB722E00B5651B /* filestr.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		96EA53A71B3CB2C700F79DC6 /* recvol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5918DB722E00B5651B /* recvol.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-parentheses -Xanalyzer -analyzer-disable-all-checks -Wno-unused-command-line-argument"; }; };
-		96EA53A81B3CB2C700F79DC6 /* rs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5F18DB722E00B5651B /* rs.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		96EA53A91B3CB2C700F79DC6 /* scantree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6318DB722E00B5651B /* scantree.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-logical-op-parentheses -Xanalyzer -analyzer-disable-all-checks -Wno-unused-command-line-argument"; }; };
-		96EA53AA1B3CB2C700F79DC6 /* qopen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FC919ED8B4E00DAF8F1 /* qopen.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks -Wno-unused-variable"; }; };
-		96EA53AB1B3CB2C700F79DC6 /* dll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1818DB722E00B5651B /* dll.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks -Wno-parentheses"; }; };
 		96EA53AC1B3CB2C700F79DC6 /* URKArchive.mm in Sources */ = {isa = PBXBuildFile; fileRef = 489CFA0F128B5169005DCC2A /* URKArchive.mm */; };
 /* End PBXBuildFile section */
 
@@ -1024,58 +974,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				96EA53781B3CB2C700F79DC6 /* rar.cpp in Sources */,
-				96EA53791B3CB2C700F79DC6 /* strlist.cpp in Sources */,
-				96EA537A1B3CB2C700F79DC6 /* strfn.cpp in Sources */,
-				96EA537B1B3CB2C700F79DC6 /* pathfn.cpp in Sources */,
-				96EA537C1B3CB2C700F79DC6 /* smallfn.cpp in Sources */,
-				96EA537D1B3CB2C700F79DC6 /* global.cpp in Sources */,
 				96EA537E1B3CB2C700F79DC6 /* URKFileInfo.m in Sources */,
-				96EA537F1B3CB2C700F79DC6 /* file.cpp in Sources */,
-				96EA53801B3CB2C700F79DC6 /* filefn.cpp in Sources */,
-				96EA53811B3CB2C700F79DC6 /* filcreat.cpp in Sources */,
-				96EA53821B3CB2C700F79DC6 /* archive.cpp in Sources */,
-				96EA53831B3CB2C700F79DC6 /* arcread.cpp in Sources */,
-				96EA53841B3CB2C700F79DC6 /* unicode.cpp in Sources */,
-				96EA53851B3CB2C700F79DC6 /* system.cpp in Sources */,
-				96EA53861B3CB2C700F79DC6 /* isnt.cpp in Sources */,
-				96EA53871B3CB2C700F79DC6 /* crypt.cpp in Sources */,
-				96EA53881B3CB2C700F79DC6 /* crc.cpp in Sources */,
-				96EA53891B3CB2C700F79DC6 /* rawread.cpp in Sources */,
-				96EA538A1B3CB2C700F79DC6 /* encname.cpp in Sources */,
-				96EA538B1B3CB2C700F79DC6 /* resource.cpp in Sources */,
-				96EA538C1B3CB2C700F79DC6 /* match.cpp in Sources */,
-				96EA538D1B3CB2C700F79DC6 /* timefn.cpp in Sources */,
-				96EA538E1B3CB2C700F79DC6 /* rdwrfn.cpp in Sources */,
-				96EA538F1B3CB2C700F79DC6 /* consio.cpp in Sources */,
-				96EA53901B3CB2C700F79DC6 /* options.cpp in Sources */,
-				96EA53911B3CB2C700F79DC6 /* errhnd.cpp in Sources */,
-				96EA53921B3CB2C700F79DC6 /* rarvm.cpp in Sources */,
-				96EA53931B3CB2C700F79DC6 /* secpassword.cpp in Sources */,
-				96EA53941B3CB2C700F79DC6 /* rijndael.cpp in Sources */,
-				96EA53951B3CB2C700F79DC6 /* getbits.cpp in Sources */,
 				96EA53961B3CB2C700F79DC6 /* NSString+UnrarKit.mm in Sources */,
-				96EA53971B3CB2C700F79DC6 /* sha1.cpp in Sources */,
-				96EA53981B3CB2C700F79DC6 /* sha256.cpp in Sources */,
-				96EA53991B3CB2C700F79DC6 /* blake2s.cpp in Sources */,
-				96EA539A1B3CB2C700F79DC6 /* hash.cpp in Sources */,
-				96EA539B1B3CB2C700F79DC6 /* extinfo.cpp in Sources */,
-				96EA539C1B3CB2C700F79DC6 /* extract.cpp in Sources */,
-				96EA539D1B3CB2C700F79DC6 /* volume.cpp in Sources */,
-				96EA539E1B3CB2C700F79DC6 /* list.cpp in Sources */,
-				96EA539F1B3CB2C700F79DC6 /* find.cpp in Sources */,
-				96EA53A01B3CB2C700F79DC6 /* unpack.cpp in Sources */,
-				96EA53A11B3CB2C700F79DC6 /* headers.cpp in Sources */,
-				96EA53A21B3CB2C700F79DC6 /* threadpool.cpp in Sources */,
-				96EA53A31B3CB2C700F79DC6 /* rs16.cpp in Sources */,
-				96EA53A41B3CB2C700F79DC6 /* cmddata.cpp in Sources */,
-				96EA53A51B3CB2C700F79DC6 /* ui.cpp in Sources */,
-				96EA53A61B3CB2C700F79DC6 /* filestr.cpp in Sources */,
-				96EA53A71B3CB2C700F79DC6 /* recvol.cpp in Sources */,
-				96EA53A81B3CB2C700F79DC6 /* rs.cpp in Sources */,
-				96EA53A91B3CB2C700F79DC6 /* scantree.cpp in Sources */,
-				96EA53AA1B3CB2C700F79DC6 /* qopen.cpp in Sources */,
-				96EA53AB1B3CB2C700F79DC6 /* dll.cpp in Sources */,
 				96EA53AC1B3CB2C700F79DC6 /* URKArchive.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1463,10 +1363,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				WARNING_CFLAGS = (
-					"-Wno-shorten-64-to-32",
-					"-Wdocumentation",
-				);
+                WARNING_CFLAGS = (
+                    "-Wno-shorten-64-to-32",
+                    "-Wdocumentation",
+                );
 			};
 			name = Debug;
 		};
@@ -1510,10 +1410,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				VALIDATE_PRODUCT = YES;
-				WARNING_CFLAGS = (
-					"-Wno-shorten-64-to-32",
-					"-Wdocumentation",
-				);
+                WARNING_CFLAGS = (
+                    "-Wno-shorten-64-to-32",
+                    "-Wdocumentation",
+                );
 			};
 			name = Release;
 		};

--- a/UnrarKit.xcodeproj/project.pbxproj
+++ b/UnrarKit.xcodeproj/project.pbxproj
@@ -10,6 +10,112 @@
 		7A22B1F81F60A2D3004B8050 /* UnrarKit.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7A22B1FA1F60A2D3004B8050 /* UnrarKit.strings */; };
 		7A22B1FB1F60A39E004B8050 /* UnrarKitResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7A22B1EA1F60A05F004B8050 /* UnrarKitResources.bundle */; };
 		7A267F6E1F713B970004EAA6 /* ProgressReportingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A267F6D1F713B970004EAA6 /* ProgressReportingTests.m */; };
+		7AC29A611F83C0D600DA4DE6 /* rar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F4A18DB722E00B5651B /* rar.cpp */; };
+		7AC29A621F83C0DD00DA4DE6 /* strlist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6D18DB722E00B5651B /* strlist.cpp */; };
+		7AC29A631F83C0E200DA4DE6 /* strfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6B18DB722E00B5651B /* strfn.cpp */; };
+		7AC29A641F83C0F000DA4DE6 /* pathfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F4818DB722E00B5651B /* pathfn.cpp */; };
+		7AC29A651F83C10200DA4DE6 /* smallfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6918DB722E00B5651B /* smallfn.cpp */; };
+		7AC29A661F83C11400DA4DE6 /* global.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F3018DB722E00B5651B /* global.cpp */; };
+		7AC29A671F83C12200DA4DE6 /* file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2618DB722E00B5651B /* file.cpp */; };
+		7AC29A681F83C12D00DA4DE6 /* filefn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2818DB722E00B5651B /* filefn.cpp */; };
+		7AC29A691F83C13600DA4DE6 /* filcreat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2418DB722E00B5651B /* filcreat.cpp */; };
+		7AC29A6A1F83C13D00DA4DE6 /* archive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F0818DB722E00B5651B /* archive.cpp */; };
+		7AC29A6B1F83C14200DA4DE6 /* arcread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F0A18DB722E00B5651B /* arcread.cpp */; };
+		7AC29A6C1F83C14D00DA4DE6 /* unicode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F7718DB722E00B5651B /* unicode.cpp */; };
+		7AC29A6D1F83C15400DA4DE6 /* system.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F7118DB722E00B5651B /* system.cpp */; };
+		7AC29A6E1F83C16500DA4DE6 /* isnt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F3318DB722E00B5651B /* isnt.cpp */; };
+		7AC29A6F1F83C16D00DA4DE6 /* crypt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1618DB722E00B5651B /* crypt.cpp */; };
+		7AC29A701F83C17300DA4DE6 /* crc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1418DB722E00B5651B /* crc.cpp */; };
+		7AC29A711F83C17900DA4DE6 /* rawread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5418DB722E00B5651B /* rawread.cpp */; };
+		7AC29A721F83C1CD00DA4DE6 /* consio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1218DB722E00B5651B /* consio.cpp */; };
+		7AC29A731F83C1CD00DA4DE6 /* encname.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1C18DB722E00B5651B /* encname.cpp */; };
+		7AC29A741F83C1CD00DA4DE6 /* errhnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1E18DB722E00B5651B /* errhnd.cpp */; };
+		7AC29A751F83C1CD00DA4DE6 /* getbits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2E18DB722E00B5651B /* getbits.cpp */; };
+		7AC29A761F83C1CD00DA4DE6 /* match.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F3F18DB722E00B5651B /* match.cpp */; };
+		7AC29A771F83C1CD00DA4DE6 /* options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F4418DB722E00B5651B /* options.cpp */; };
+		7AC29A781F83C1CD00DA4DE6 /* rarvm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5118DB722E00B5651B /* rarvm.cpp */; };
+		7AC29A791F83C1CD00DA4DE6 /* rdwrfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5618DB722E00B5651B /* rdwrfn.cpp */; };
+		7AC29A7A1F83C1CD00DA4DE6 /* resource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5B18DB722E00B5651B /* resource.cpp */; };
+		7AC29A7B1F83C1CD00DA4DE6 /* rijndael.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5D18DB722E00B5651B /* rijndael.cpp */; };
+		7AC29A7C1F83C1CD00DA4DE6 /* secpassword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6518DB722E00B5651B /* secpassword.cpp */; };
+		7AC29A7D1F83C1CD00DA4DE6 /* timefn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F7318DB722E00B5651B /* timefn.cpp */; };
+		7AC29A7E1F83C21700DA4DE6 /* blake2s.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FB419ED8A8200DAF8F1 /* blake2s.cpp */; };
+		7AC29A7F1F83C21700DA4DE6 /* cmddata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F0D18DB722E00B5651B /* cmddata.cpp */; };
+		7AC29A801F83C21700DA4DE6 /* dll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F1818DB722E00B5651B /* dll.cpp */; };
+		7AC29A811F83C21700DA4DE6 /* extinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2018DB722E00B5651B /* extinfo.cpp */; };
+		7AC29A821F83C21700DA4DE6 /* extract.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2218DB722E00B5651B /* extract.cpp */; };
+		7AC29A831F83C21700DA4DE6 /* filestr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2A18DB722E00B5651B /* filestr.cpp */; };
+		7AC29A841F83C21700DA4DE6 /* find.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F2C18DB722E00B5651B /* find.cpp */; };
+		7AC29A851F83C21700DA4DE6 /* hash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FC419ED8B0400DAF8F1 /* hash.cpp */; };
+		7AC29A861F83C21700DA4DE6 /* headers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FC619ED8B1F00DAF8F1 /* headers.cpp */; };
+		7AC29A871F83C21700DA4DE6 /* list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F3618DB722E00B5651B /* list.cpp */; };
+		7AC29A881F83C21700DA4DE6 /* qopen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FC919ED8B4E00DAF8F1 /* qopen.cpp */; };
+		7AC29A891F83C21700DA4DE6 /* recvol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5918DB722E00B5651B /* recvol.cpp */; };
+		7AC29A8A1F83C21700DA4DE6 /* rs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F5F18DB722E00B5651B /* rs.cpp */; };
+		7AC29A8B1F83C21700DA4DE6 /* rs16.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FCD19ED8B9700DAF8F1 /* rs16.cpp */; };
+		7AC29A8C1F83C21700DA4DE6 /* scantree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6318DB722E00B5651B /* scantree.cpp */; };
+		7AC29A8D1F83C21700DA4DE6 /* sha1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F6718DB722E00B5651B /* sha1.cpp */; };
+		7AC29A8E1F83C21700DA4DE6 /* sha256.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FCF19ED8BB200DAF8F1 /* sha256.cpp */; };
+		7AC29A8F1F83C21700DA4DE6 /* threadpool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FD219ED8C6100DAF8F1 /* threadpool.cpp */; };
+		7AC29A901F83C21700DA4DE6 /* ui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96370FD419ED8C8000DAF8F1 /* ui.cpp */; };
+		7AC29A911F83C21700DA4DE6 /* unpack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F7A18DB722E00B5651B /* unpack.cpp */; };
+		7AC29A921F83C21700DA4DE6 /* volume.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96853F8218DB722F00B5651B /* volume.cpp */; };
+		7AC29A931F83C2A200DA4DE6 /* dll.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1A18DB722E00B5651B /* dll.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AC29A941F83C2A200DA4DE6 /* raros.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4E18DB722E00B5651B /* raros.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AC29A951F83C36900DA4DE6 /* archive.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F0918DB722E00B5651B /* archive.hpp */; };
+		7AC29A961F83C36900DA4DE6 /* array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F0B18DB722E00B5651B /* array.hpp */; };
+		7AC29A971F83C36900DA4DE6 /* cmddata.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F0E18DB722E00B5651B /* cmddata.hpp */; };
+		7AC29A981F83C36900DA4DE6 /* coder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1018DB722E00B5651B /* coder.hpp */; };
+		7AC29A991F83C36900DA4DE6 /* compress.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1118DB722E00B5651B /* compress.hpp */; };
+		7AC29A9A1F83C36900DA4DE6 /* consio.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1318DB722E00B5651B /* consio.hpp */; };
+		7AC29A9B1F83C36900DA4DE6 /* crc.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1518DB722E00B5651B /* crc.hpp */; };
+		7AC29A9C1F83C36900DA4DE6 /* crypt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1718DB722E00B5651B /* crypt.hpp */; };
+		7AC29A9D1F83C36900DA4DE6 /* encname.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1D18DB722E00B5651B /* encname.hpp */; };
+		7AC29A9E1F83C36900DA4DE6 /* errhnd.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F1F18DB722E00B5651B /* errhnd.hpp */; };
+		7AC29A9F1F83C36900DA4DE6 /* extinfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2118DB722E00B5651B /* extinfo.hpp */; };
+		7AC29AA01F83C36900DA4DE6 /* extract.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2318DB722E00B5651B /* extract.hpp */; };
+		7AC29AA11F83C36900DA4DE6 /* filcreat.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2518DB722E00B5651B /* filcreat.hpp */; };
+		7AC29AA21F83C36900DA4DE6 /* file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2718DB722E00B5651B /* file.hpp */; };
+		7AC29AA31F83C36900DA4DE6 /* filefn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2918DB722E00B5651B /* filefn.hpp */; };
+		7AC29AA41F83C36900DA4DE6 /* filestr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2B18DB722E00B5651B /* filestr.hpp */; };
+		7AC29AA51F83C36900DA4DE6 /* find.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2D18DB722E00B5651B /* find.hpp */; };
+		7AC29AA61F83C36900DA4DE6 /* getbits.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F2F18DB722E00B5651B /* getbits.hpp */; };
+		7AC29AA71F83C36900DA4DE6 /* global.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3118DB722E00B5651B /* global.hpp */; };
+		7AC29AA81F83C36900DA4DE6 /* headers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3218DB722E00B5651B /* headers.hpp */; };
+		7AC29AA91F83C36900DA4DE6 /* isnt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3418DB722E00B5651B /* isnt.hpp */; };
+		7AC29AAA1F83C36900DA4DE6 /* list.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3718DB722E00B5651B /* list.hpp */; };
+		7AC29AAB1F83C36900DA4DE6 /* loclang.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3818DB722E00B5651B /* loclang.hpp */; };
+		7AC29AAC1F83C36900DA4DE6 /* log.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F3A18DB722E00B5651B /* log.hpp */; };
+		7AC29AAD1F83C36900DA4DE6 /* match.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4018DB722E00B5651B /* match.hpp */; };
+		7AC29AAE1F83C36900DA4DE6 /* model.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4218DB722E00B5651B /* model.hpp */; };
+		7AC29AAF1F83C36900DA4DE6 /* options.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4518DB722E00B5651B /* options.hpp */; };
+		7AC29AB01F83C36900DA4DE6 /* os.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4618DB722E00B5651B /* os.hpp */; };
+		7AC29AB11F83C36900DA4DE6 /* pathfn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4918DB722E00B5651B /* pathfn.hpp */; };
+		7AC29AB21F83C36900DA4DE6 /* rar.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4B18DB722E00B5651B /* rar.hpp */; };
+		7AC29AB31F83C36900DA4DE6 /* rardefs.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4C18DB722E00B5651B /* rardefs.hpp */; };
+		7AC29AB41F83C36900DA4DE6 /* rarlang.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F4D18DB722E00B5651B /* rarlang.hpp */; };
+		7AC29AB51F83C36900DA4DE6 /* rartypes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5018DB722E00B5651B /* rartypes.hpp */; };
+		7AC29AB61F83C36900DA4DE6 /* rarvm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5218DB722E00B5651B /* rarvm.hpp */; };
+		7AC29AB71F83C36900DA4DE6 /* rawread.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5518DB722E00B5651B /* rawread.hpp */; };
+		7AC29AB81F83C36900DA4DE6 /* rdwrfn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5718DB722E00B5651B /* rdwrfn.hpp */; };
+		7AC29AB91F83C36900DA4DE6 /* recvol.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5A18DB722E00B5651B /* recvol.hpp */; };
+		7AC29ABA1F83C36900DA4DE6 /* resource.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5C18DB722E00B5651B /* resource.hpp */; };
+		7AC29ABB1F83C36900DA4DE6 /* rijndael.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F5E18DB722E00B5651B /* rijndael.hpp */; };
+		7AC29ABC1F83C36900DA4DE6 /* rs.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6018DB722E00B5651B /* rs.hpp */; };
+		7AC29ABD1F83C36900DA4DE6 /* savepos.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6218DB722E00B5651B /* savepos.hpp */; };
+		7AC29ABE1F83C36900DA4DE6 /* scantree.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6418DB722E00B5651B /* scantree.hpp */; };
+		7AC29ABF1F83C36900DA4DE6 /* secpassword.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6618DB722E00B5651B /* secpassword.hpp */; };
+		7AC29AC01F83C36900DA4DE6 /* sha1.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6818DB722E00B5651B /* sha1.hpp */; };
+		7AC29AC11F83C36900DA4DE6 /* smallfn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6A18DB722E00B5651B /* smallfn.hpp */; };
+		7AC29AC21F83C36900DA4DE6 /* strfn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6C18DB722E00B5651B /* strfn.hpp */; };
+		7AC29AC31F83C36900DA4DE6 /* strlist.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F6E18DB722E00B5651B /* strlist.hpp */; };
+		7AC29AC41F83C36900DA4DE6 /* suballoc.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7018DB722E00B5651B /* suballoc.hpp */; };
+		7AC29AC51F83C36900DA4DE6 /* system.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7218DB722E00B5651B /* system.hpp */; };
+		7AC29AC61F83C36900DA4DE6 /* timefn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7418DB722E00B5651B /* timefn.hpp */; };
+		7AC29AC71F83C36900DA4DE6 /* unicode.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7818DB722E00B5651B /* unicode.hpp */; };
+		7AC29AC81F83C36900DA4DE6 /* unpack.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F7B18DB722E00B5651B /* unpack.hpp */; };
+		7AC29AC91F83C36900DA4DE6 /* version.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F8118DB722F00B5651B /* version.hpp */; };
+		7AC29ACA1F83C36900DA4DE6 /* volume.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 96853F8318DB722F00B5651B /* volume.hpp */; };
 		964C8AC718D28EE000AD7321 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 964C8AC518D28EE000AD7321 /* InfoPlist.strings */; };
 		9660D7AF1A3F4FF90059AC1E /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9660D7AE1A3F4FF90059AC1E /* libz.dylib */; };
 		967872741E460FA70048A54C /* ListVolumesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 967872731E460FA70048A54C /* ListVolumesTests.m */; };
@@ -166,6 +272,7 @@
 		7A22B1EA1F60A05F004B8050 /* UnrarKitResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnrarKitResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A22B1F91F60A2D3004B8050 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/UnrarKit.strings; sourceTree = "<group>"; };
 		7A267F6D1F713B970004EAA6 /* ProgressReportingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProgressReportingTests.m; sourceTree = "<group>"; };
+		7AC29A5D1F83C08200DA4DE6 /* libunrar.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libunrar.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		96370FB319ED8A8200DAF8F1 /* blake2s_sse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blake2s_sse.cpp; sourceTree = "<group>"; };
 		96370FB419ED8A8200DAF8F1 /* blake2s.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blake2s.cpp; sourceTree = "<group>"; };
 		96370FB519ED8A8200DAF8F1 /* blake2s.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blake2s.hpp; sourceTree = "<group>"; };
@@ -350,6 +457,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7AC29A5A1F83C08200DA4DE6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		964C8AB818D28EE000AD7321 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -375,6 +489,7 @@
 				96EA535B1B3CB04300F79DC6 /* UnrarKit.framework */,
 				964C8ABB18D28EE000AD7321 /* UnrarKit Tests.xctest */,
 				7A22B1EA1F60A05F004B8050 /* UnrarKitResources.bundle */,
+				7AC29A5D1F83C08200DA4DE6 /* libunrar.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -647,6 +762,69 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		7AC29A5B1F83C08200DA4DE6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7AC29A931F83C2A200DA4DE6 /* dll.hpp in Headers */,
+				7AC29A941F83C2A200DA4DE6 /* raros.hpp in Headers */,
+				7AC29A951F83C36900DA4DE6 /* archive.hpp in Headers */,
+				7AC29A961F83C36900DA4DE6 /* array.hpp in Headers */,
+				7AC29A971F83C36900DA4DE6 /* cmddata.hpp in Headers */,
+				7AC29A981F83C36900DA4DE6 /* coder.hpp in Headers */,
+				7AC29A991F83C36900DA4DE6 /* compress.hpp in Headers */,
+				7AC29A9A1F83C36900DA4DE6 /* consio.hpp in Headers */,
+				7AC29A9B1F83C36900DA4DE6 /* crc.hpp in Headers */,
+				7AC29A9C1F83C36900DA4DE6 /* crypt.hpp in Headers */,
+				7AC29A9D1F83C36900DA4DE6 /* encname.hpp in Headers */,
+				7AC29A9E1F83C36900DA4DE6 /* errhnd.hpp in Headers */,
+				7AC29A9F1F83C36900DA4DE6 /* extinfo.hpp in Headers */,
+				7AC29AA01F83C36900DA4DE6 /* extract.hpp in Headers */,
+				7AC29AA11F83C36900DA4DE6 /* filcreat.hpp in Headers */,
+				7AC29AA21F83C36900DA4DE6 /* file.hpp in Headers */,
+				7AC29AA31F83C36900DA4DE6 /* filefn.hpp in Headers */,
+				7AC29AA41F83C36900DA4DE6 /* filestr.hpp in Headers */,
+				7AC29AA51F83C36900DA4DE6 /* find.hpp in Headers */,
+				7AC29AA61F83C36900DA4DE6 /* getbits.hpp in Headers */,
+				7AC29AA71F83C36900DA4DE6 /* global.hpp in Headers */,
+				7AC29AA81F83C36900DA4DE6 /* headers.hpp in Headers */,
+				7AC29AA91F83C36900DA4DE6 /* isnt.hpp in Headers */,
+				7AC29AAA1F83C36900DA4DE6 /* list.hpp in Headers */,
+				7AC29AAB1F83C36900DA4DE6 /* loclang.hpp in Headers */,
+				7AC29AAC1F83C36900DA4DE6 /* log.hpp in Headers */,
+				7AC29AAD1F83C36900DA4DE6 /* match.hpp in Headers */,
+				7AC29AAE1F83C36900DA4DE6 /* model.hpp in Headers */,
+				7AC29AAF1F83C36900DA4DE6 /* options.hpp in Headers */,
+				7AC29AB01F83C36900DA4DE6 /* os.hpp in Headers */,
+				7AC29AB11F83C36900DA4DE6 /* pathfn.hpp in Headers */,
+				7AC29AB21F83C36900DA4DE6 /* rar.hpp in Headers */,
+				7AC29AB31F83C36900DA4DE6 /* rardefs.hpp in Headers */,
+				7AC29AB41F83C36900DA4DE6 /* rarlang.hpp in Headers */,
+				7AC29AB51F83C36900DA4DE6 /* rartypes.hpp in Headers */,
+				7AC29AB61F83C36900DA4DE6 /* rarvm.hpp in Headers */,
+				7AC29AB71F83C36900DA4DE6 /* rawread.hpp in Headers */,
+				7AC29AB81F83C36900DA4DE6 /* rdwrfn.hpp in Headers */,
+				7AC29AB91F83C36900DA4DE6 /* recvol.hpp in Headers */,
+				7AC29ABA1F83C36900DA4DE6 /* resource.hpp in Headers */,
+				7AC29ABB1F83C36900DA4DE6 /* rijndael.hpp in Headers */,
+				7AC29ABC1F83C36900DA4DE6 /* rs.hpp in Headers */,
+				7AC29ABD1F83C36900DA4DE6 /* savepos.hpp in Headers */,
+				7AC29ABE1F83C36900DA4DE6 /* scantree.hpp in Headers */,
+				7AC29ABF1F83C36900DA4DE6 /* secpassword.hpp in Headers */,
+				7AC29AC01F83C36900DA4DE6 /* sha1.hpp in Headers */,
+				7AC29AC11F83C36900DA4DE6 /* smallfn.hpp in Headers */,
+				7AC29AC21F83C36900DA4DE6 /* strfn.hpp in Headers */,
+				7AC29AC31F83C36900DA4DE6 /* strlist.hpp in Headers */,
+				7AC29AC41F83C36900DA4DE6 /* suballoc.hpp in Headers */,
+				7AC29AC51F83C36900DA4DE6 /* system.hpp in Headers */,
+				7AC29AC61F83C36900DA4DE6 /* timefn.hpp in Headers */,
+				7AC29AC71F83C36900DA4DE6 /* unicode.hpp in Headers */,
+				7AC29AC81F83C36900DA4DE6 /* unpack.hpp in Headers */,
+				7AC29AC91F83C36900DA4DE6 /* version.hpp in Headers */,
+				7AC29ACA1F83C36900DA4DE6 /* volume.hpp in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		96EA53581B3CB04300F79DC6 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -734,6 +912,23 @@
 			productReference = 7A22B1EA1F60A05F004B8050 /* UnrarKitResources.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		7AC29A5C1F83C08200DA4DE6 /* unrar */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7AC29A601F83C08200DA4DE6 /* Build configuration list for PBXNativeTarget "unrar" */;
+			buildPhases = (
+				7AC29A591F83C08200DA4DE6 /* Sources */,
+				7AC29A5A1F83C08200DA4DE6 /* Frameworks */,
+				7AC29A5B1F83C08200DA4DE6 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = unrar;
+			productName = unrar;
+			productReference = 7AC29A5D1F83C08200DA4DE6 /* libunrar.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		964C8ABA18D28EE000AD7321 /* UnrarKit Tests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 964C8ACF18D28EE000AD7321 /* Build configuration list for PBXNativeTarget "UnrarKit Tests" */;
@@ -784,6 +979,10 @@
 						CreatedOnToolsVersion = 8.3.3;
 						ProvisioningStyle = Automatic;
 					};
+					7AC29A5C1F83C08200DA4DE6 = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
+					};
 					964C8ABA18D28EE000AD7321 = {
 						LastSwiftMigration = 0820;
 						TestTargetID = 96853EDA18DB71CD00B5651B;
@@ -814,6 +1013,7 @@
 				96EA535A1B3CB04300F79DC6 /* UnrarKit */,
 				964C8ABA18D28EE000AD7321 /* UnrarKit Tests */,
 				7A22B1E91F60A05F004B8050 /* UnrarKitResources */,
+				7AC29A5C1F83C08200DA4DE6 /* unrar */,
 			);
 		};
 /* End PBXProject section */
@@ -851,6 +1051,63 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7AC29A591F83C08200DA4DE6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7AC29A611F83C0D600DA4DE6 /* rar.cpp in Sources */,
+				7AC29A621F83C0DD00DA4DE6 /* strlist.cpp in Sources */,
+				7AC29A631F83C0E200DA4DE6 /* strfn.cpp in Sources */,
+				7AC29A641F83C0F000DA4DE6 /* pathfn.cpp in Sources */,
+				7AC29A651F83C10200DA4DE6 /* smallfn.cpp in Sources */,
+				7AC29A661F83C11400DA4DE6 /* global.cpp in Sources */,
+				7AC29A671F83C12200DA4DE6 /* file.cpp in Sources */,
+				7AC29A681F83C12D00DA4DE6 /* filefn.cpp in Sources */,
+				7AC29A691F83C13600DA4DE6 /* filcreat.cpp in Sources */,
+				7AC29A6A1F83C13D00DA4DE6 /* archive.cpp in Sources */,
+				7AC29A6B1F83C14200DA4DE6 /* arcread.cpp in Sources */,
+				7AC29A6C1F83C14D00DA4DE6 /* unicode.cpp in Sources */,
+				7AC29A6D1F83C15400DA4DE6 /* system.cpp in Sources */,
+				7AC29A6E1F83C16500DA4DE6 /* isnt.cpp in Sources */,
+				7AC29A6F1F83C16D00DA4DE6 /* crypt.cpp in Sources */,
+				7AC29A701F83C17300DA4DE6 /* crc.cpp in Sources */,
+				7AC29A711F83C17900DA4DE6 /* rawread.cpp in Sources */,
+				7AC29A731F83C1CD00DA4DE6 /* encname.cpp in Sources */,
+				7AC29A7A1F83C1CD00DA4DE6 /* resource.cpp in Sources */,
+				7AC29A761F83C1CD00DA4DE6 /* match.cpp in Sources */,
+				7AC29A7D1F83C1CD00DA4DE6 /* timefn.cpp in Sources */,
+				7AC29A791F83C1CD00DA4DE6 /* rdwrfn.cpp in Sources */,
+				7AC29A721F83C1CD00DA4DE6 /* consio.cpp in Sources */,
+				7AC29A771F83C1CD00DA4DE6 /* options.cpp in Sources */,
+				7AC29A741F83C1CD00DA4DE6 /* errhnd.cpp in Sources */,
+				7AC29A781F83C1CD00DA4DE6 /* rarvm.cpp in Sources */,
+				7AC29A7C1F83C1CD00DA4DE6 /* secpassword.cpp in Sources */,
+				7AC29A7B1F83C1CD00DA4DE6 /* rijndael.cpp in Sources */,
+				7AC29A751F83C1CD00DA4DE6 /* getbits.cpp in Sources */,
+				7AC29A8D1F83C21700DA4DE6 /* sha1.cpp in Sources */,
+				7AC29A8E1F83C21700DA4DE6 /* sha256.cpp in Sources */,
+				7AC29A7E1F83C21700DA4DE6 /* blake2s.cpp in Sources */,
+				7AC29A851F83C21700DA4DE6 /* hash.cpp in Sources */,
+				7AC29A811F83C21700DA4DE6 /* extinfo.cpp in Sources */,
+				7AC29A821F83C21700DA4DE6 /* extract.cpp in Sources */,
+				7AC29A921F83C21700DA4DE6 /* volume.cpp in Sources */,
+				7AC29A871F83C21700DA4DE6 /* list.cpp in Sources */,
+				7AC29A841F83C21700DA4DE6 /* find.cpp in Sources */,
+				7AC29A911F83C21700DA4DE6 /* unpack.cpp in Sources */,
+				7AC29A861F83C21700DA4DE6 /* headers.cpp in Sources */,
+				7AC29A8F1F83C21700DA4DE6 /* threadpool.cpp in Sources */,
+				7AC29A8B1F83C21700DA4DE6 /* rs16.cpp in Sources */,
+				7AC29A7F1F83C21700DA4DE6 /* cmddata.cpp in Sources */,
+				7AC29A901F83C21700DA4DE6 /* ui.cpp in Sources */,
+				7AC29A831F83C21700DA4DE6 /* filestr.cpp in Sources */,
+				7AC29A891F83C21700DA4DE6 /* recvol.cpp in Sources */,
+				7AC29A8A1F83C21700DA4DE6 /* rs.cpp in Sources */,
+				7AC29A8C1F83C21700DA4DE6 /* scantree.cpp in Sources */,
+				7AC29A881F83C21700DA4DE6 /* qopen.cpp in Sources */,
+				7AC29A801F83C21700DA4DE6 /* dll.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1137,6 +1394,62 @@
 			};
 			name = Release;
 		};
+		7AC29A5E1F83C08200DA4DE6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				EXECUTABLE_PREFIX = lib;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		7AC29A5F1F83C08200DA4DE6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				EXECUTABLE_PREFIX = lib;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		964C8ACD18D28EE000AD7321 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1316,6 +1629,15 @@
 			buildConfigurations = (
 				7A22B1ED1F60A05F004B8050 /* Debug */,
 				7A22B1EE1F60A05F004B8050 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7AC29A601F83C08200DA4DE6 /* Build configuration list for PBXNativeTarget "unrar" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7AC29A5E1F83C08200DA4DE6 /* Debug */,
+				7AC29A5F1F83C08200DA4DE6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Split the `unrar` sources into their own static library with all warnings turned off, and compile UnrarKit with `-Weverything`, addressing all warnings that turns up (Issue #56).