### PR TITLE
Fix listFileInfo for multi-volume archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added methods for checking data integrity of archived files (Issue #26, PR #61 - Thanks to [@amosavian](https://github.com/amosavian) for the suggestion!)
 * Added detailed logging using new unified logging framework. See [the readme](README.md) for more details (Issue #35)
 * Added localized details to returned `NSError` objects (Issue #45)
+* Fixed bug when listing file info for multivolume archive that resulted in duplicate items (Issue #67 - Thanks to [@skito](https://github.com/skito) for catching this)
 * Moved `unrar` sources into a static library, and addressed a wide variety of warnings exposed by the `-Weverything` flag (Issue #56)
 * Switched to Travis Build Stages instead of the unofficial Travis-After-All (Issue #42)
 * Fixed warnings from Xcode 9 (Issue #51)

--- a/Classes/URKArchive.mm
+++ b/Classes/URKArchive.mm
@@ -481,6 +481,8 @@ NS_DESIGNATED_INITIALIZER
 
     NSProgress *progress = [self beginProgressOperation:totalSize.longLongValue];
     progress.kind = NSProgressKindFile;
+    
+    URKLogDebug("Archive has total size of %{iec-bytes}lld", totalSize.longLongValue);
 	
     __weak URKArchive *welf = self;
 
@@ -489,11 +491,13 @@ NS_DESIGNATED_INITIALIZER
 
         int RHCode = 0, PFCode = 0, filesExtracted = 0;
         URKFileInfo *fileInfo;
+        
+        URKLogInfo("Extracting to %{public}@", filePath);
 
         URKLogDebug("Reading through RAR header looking for files...");
         while ((RHCode = RARReadHeaderEx(welf.rarFile, welf.header)) == ERAR_SUCCESS) {
             fileInfo = [URKFileInfo fileInfo:welf.header];
-            URKLogDebug("Extracting %{public}@", fileInfo.filename);
+            URKLogDebug("Extracting %{public}@ (%{iec-bytes}lld)", fileInfo.filename, fileInfo.uncompressedSize);
             NSURL *extractedURL = [[NSURL fileURLWithPath:filePath] URLByAppendingPathComponent:fileInfo.filename];
             [progress setUserInfoObject:extractedURL
                                  forKey:NSProgressFileURLKey];
@@ -527,6 +531,8 @@ NS_DESIGNATED_INITIALIZER
             [progress setUserInfoObject:@(fileInfos.count)
                                  forKey:NSProgressFileTotalCountKey];
             progress.completedUnitCount += fileInfo.uncompressedSize;
+            
+            URKLogDebug("Finished extracting %{public}@. Extraction %f complete", fileInfo.filename, progress.fractionCompleted);
             
             if (progressBlock) {
 #pragma clang diagnostic push

--- a/Classes/URKArchive.mm
+++ b/Classes/URKArchive.mm
@@ -374,6 +374,7 @@ NS_DESIGNATED_INITIALIZER
 {
     URKCreateActivity("Listing File Info");
 
+    NSMutableSet *filenames = [NSMutableSet set];
     __block NSMutableArray *fileInfos = [NSMutableArray array];
     __weak URKArchive *welf = self;
 
@@ -385,8 +386,16 @@ NS_DESIGNATED_INITIALIZER
         URKLogDebug("Reading through RAR header looking for files...");
         
         while ((RHCode = RARReadHeaderEx(welf.rarFile, welf.header)) == 0) {
-            URKLogDebug("Adding object");
-            [fileInfos addObject:[URKFileInfo fileInfo:welf.header]];
+            URKFileInfo *fileInfo = [URKFileInfo fileInfo:welf.header];
+            
+            if (![filenames containsObject:fileInfo.filename]) {
+                URKLogDebug("Adding object");
+                [fileInfos addObject:fileInfo];
+                [filenames addObject:fileInfo.filename];
+            }
+            else {
+                URKLogDebug("Not adding %{public}@ to list of file infos, as it has already been listed", fileInfo.filename)
+            }
 
             URKLogDebug("Skipping to next file...");
             if ((PFCode = RARProcessFile(welf.rarFile, RAR_SKIP, NULL, NULL)) != 0) {

--- a/Tests/URKArchiveTests.m
+++ b/Tests/URKArchiveTests.m
@@ -344,6 +344,19 @@ enum SignPostColor: uint {  // standard color scheme for signposts in Instrument
     }
 }
 
+#if !TARGET_OS_IPHONE
+- (void)testListFileInfo_MultivolumeArchive {
+    NSArray<NSURL*> *generatedVolumeURLs = [self multiPartArchiveWithName:@"ListFileInfoTests_MultivolumeArchive.rar"];
+    URKArchive *archive = [[URKArchive alloc] initWithURL:generatedVolumeURLs.firstObject error:nil];
+    
+    NSError *error = nil;
+    NSArray *files = [archive listFileInfo:&error];
+    
+    XCTAssertNil(error, @"Error returned when listing file info for multivolume archive");
+    XCTAssertEqual(files.count, 1, @"Incorrect number of file info items returned for multivolume archive");
+}
+#endif
+
 - (void)testListFileInfo_HeaderPassword
 {
     NSArray *testArchives = @[@"Test Archive (Header Password).rar"];

--- a/beta-notes.md
+++ b/beta-notes.md
@@ -1,1 +1,1 @@
-Fixed release notes addition, so these notes are taken from beta-notes.md
+Fixed bug when listing file info for multivolume archive that resulted in duplicate items (Issue #67 - Thanks to [@skito](https://github.com/skito) for catching this)


### PR DESCRIPTION
Refactored the guts of `-listFileInfo:` into a new method `-allFileInfo:`, so the original can filter out duplicates resulting from files that span volumes. This was resulting in an incorrect total archive size being reported for multi-volume archives.

This issue was originally reported by @skito in issue #67.