### PR TITLE
Fix lastArchivePath, lastFilepath memory management

### DIFF
--- a/Classes/URKArchive.mm
+++ b/Classes/URKArchive.mm
@@ -51,8 +51,8 @@ NS_DESIGNATED_INITIALIZER
 
 @property (strong) NSObject *threadLock;
 
-@property (assign) NSString *lastArchivePath;
-@property (assign) NSString *lastFilepath;
+@property (copy) NSString *lastArchivePath;
+@property (copy) NSString *lastFilepath;
 
 @end
 


### PR DESCRIPTION
The project can't be archived due to `-Wobjc-property-assign-on-object-type` flagging a potential memory management error defining `lastArchivePath` and `lastFilepath` properties. 

Both properties are defined as `assign` but they contain object references. A `copy` would probably work better in this case.

```
/Users/danielgarcia/.../Carthage/Checkouts/UnrarKit/Classes/URKArchive.mm:54:1: error: 'assign' property of object type may become a dangling reference; consider using 'unsafe_unretained' [-Werror,-Wobjc-property-assign-on-object-type]
@property (assign) NSString *lastArchivePath;
^
/Users/danielgarcia/.../Carthage/Checkouts/UnrarKit/Classes/URKArchive.mm:55:1: error: 'assign' property of object type may become a dangling reference; consider using 'unsafe_unretained' [-Werror,-Wobjc-property-assign-on-object-type]
@property (assign) NSString *lastFilepath;
^
2 errors generated.
```