### PR TITLE
Fix Carthage build for Xcode 12

### DIFF
--- a/Classes/URKArchive.mm
+++ b/Classes/URKArchive.mm
@@ -1485,7 +1485,7 @@ int CALLBACK AllowCancellationCallbackProc(UINT msg, long UserData, long P1, lon
 
         default:
             errorName = [NSString stringWithFormat:@"Unknown (%ld)", (long)errorCode];
-            detail = [NSString localizedStringWithFormat:NSLocalizedStringFromTableInBundle(@"Unknown error encountered (code %ld)", @"UnrarKit", _resources, @"Error detail string"), errorCode];
+            detail = [NSString localizedStringWithFormat:NSLocalizedStringFromTableInBundle(@"Unknown error encountered (code %ld)", @"UnrarKit", _resources, @"Error detail string"), (long)errorCode];
             break;
     }
 

--- a/Libraries/unrar/blake2s.hpp
+++ b/Libraries/unrar/blake2s.hpp
@@ -19,10 +19,11 @@ enum blake2s_constant
 // 'new' operator.
 struct blake2s_state
 {
-  enum { BLAKE_ALIGNMENT = 64 };
-
-  // buffer and uint32 h[8], t[2], f[2];
-  enum { BLAKE_DATA_SIZE = 48 + 2 * BLAKE2S_BLOCKBYTES };
+  enum {
+    BLAKE_ALIGNMENT = 64,
+    // buffer and uint32 h[8], t[2], f[2];
+    BLAKE_DATA_SIZE = 48 + 2 * BLAKE2S_BLOCKBYTES
+  };
 
   byte ubuf[BLAKE_DATA_SIZE + BLAKE_ALIGNMENT];
 


### PR DESCRIPTION
After updating to Xcode 12 (Swift 5.3) UnrarKit v2.9 Carthage build fails.
I'm not sure this fix is correct enough but it makes build succeed.