### PR TITLE
Add "extractBufferedDataFromFileInfo" for quick locate header and extraction

### DIFF
--- a/Classes/URKArchive.h
+++ b/Classes/URKArchive.h
@@ -474,6 +474,23 @@ extern NSString *URKErrorDomain;
                              action:(void(^)(NSData *dataChunk, CGFloat percentDecompressed))action;
 
 /**
+ *  Unarchive a single file from the archive into memory. Supports NSProgress for progress reporting, which also
+ *  allows cancellation in the middle of extraction
+ *
+ *  @param fileInfo   An URKFileInfo instance within the archive to be expanded
+ *  @param error      Contains an NSError object when there was an error reading the archive
+ *  @param action     The block to run for each chunk of data, each of size <= bufferSize
+ *
+ *       - *dataChunk*           The data read from the archived file. Read bytes and length to write the data
+ *       - *percentDecompressed* The percentage of the file that has been decompressed
+ *
+ *  @return YES if all data was read successfully, NO if an error was encountered
+ */
+- (BOOL)extractBufferedDataFromFileInfo:(URKFileInfo *)fileInfo
+                              error:(NSError **)error
+                             action:(void(^)(NSData *dataChunk, CGFloat percentDecompressed))action;
+
+/**
  *  YES if archive protected with a password, NO otherwise
  */
 - (BOOL)isPasswordProtected;

--- a/Classes/URKFileInfo.h
+++ b/Classes/URKFileInfo.h
@@ -147,6 +147,11 @@ typedef NS_ENUM(NSUInteger, URKHostOS) {
 @property (readonly, assign) URKHostOS hostOS;
 
 /**
+ *  Closest offset to file record's header
+ */
+@property (assign) int64_t closestOffsetToHeader;
+
+/**
  *  Returns a URKFileInfo instance for the given extended header data
  *
  *  @param fileHeader The header data for a RAR file

--- a/Tests/ExtractBufferedDataTests.m
+++ b/Tests/ExtractBufferedDataTests.m
@@ -26,6 +26,17 @@ enum SignPostColor: uint {  // standard color scheme for signposts in Instrument
 
 @implementation ExtractBufferedDataTests
 
+- (URKFileInfo *)getFileInfoByPath:(URKArchive *)archive
+                          filePath:(NSString *)filePath
+{
+    NSError *innerError = nil;
+    NSArray *filesInArchive = [archive listFileInfo:&innerError];
+    NSPredicate *bPredicate = [NSPredicate predicateWithFormat:@"SELF.filename ==[c] %@", filePath];
+    URKFileInfo *fileInfo = [filesInArchive filteredArrayUsingPredicate:bPredicate].firstObject;
+
+    return fileInfo;
+}
+
 - (void)testExtractBufferedData
 {
     NSURL *archiveURL = self.testFileURLs[@"Test Archive.rar"];
@@ -102,6 +113,91 @@ enum SignPostColor: uint {  // standard color scheme for signposts in Instrument
     NSData *originalFile = [NSData dataWithContentsOfURL:self.testFileURLs[extractedFile]];
     XCTAssertTrue([originalFile isEqualToData:reconstructedFile],
                   @"File extracted in buffer not returned correctly");
+}
+
+- (void)testExtractBufferedDataFromFileInfo
+{
+    NSURL *archiveURL = self.testFileURLs[@"Test Archive.rar"];
+    NSString *extractedFile = @"Test File B.jpg";
+    URKArchive *archive = [[URKArchive alloc] initWithURL:archiveURL error:nil];
+    URKFileInfo *fileInfo = [self getFileInfoByPath:archive filePath: extractedFile];
+
+    NSError *error = nil;
+    NSMutableData *reconstructedFile = [NSMutableData data];
+    BOOL success = [archive extractBufferedDataFromFileInfo:fileInfo
+                                                  error:&error
+                                                 action:
+                                                         ^(NSData *dataChunk, CGFloat percentDecompressed) {
+                                                             NSLog(@"Decompressed: %f%%", percentDecompressed);
+                                                             [reconstructedFile appendBytes:dataChunk.bytes
+                                                                                     length:dataChunk.length];
+                                                         }];
+
+    XCTAssertTrue(success, @"Failed to read buffered data");
+    XCTAssertNil(error, @"Error reading buffered data");
+    XCTAssertGreaterThan(reconstructedFile.length, 0, @"No data returned");
+
+    NSData *originalFile = [NSData dataWithContentsOfURL:self.testFileURLs[extractedFile]];
+    XCTAssertTrue([originalFile isEqualToData:reconstructedFile],
+            @"File extracted in buffer not returned correctly");
+}
+
+/*
+ * Todo: these two unit tests will fail because listFileInfo method will return nil if the CRC is corrupted,
+ * so we can't get fileInfo out from filePath, we will need a workaround
+ */
+- (void)testExtractBufferedDataFromFileInfo_ModifiedCRC
+{
+//    NSURL *archiveURL = self.testFileURLs[@"Modified CRC Archive.rar"];
+//    NSString *extractedFile = @"README.md";
+//    URKArchive *archive = [[URKArchive alloc] initWithURL:archiveURL error:nil];
+//    URKFileInfo *fileInfo = [self getFileInfoByPath:archive filePath: extractedFile];
+//
+//    NSError *error = nil;
+//    NSMutableData *reconstructedFile = [NSMutableData data];
+//    BOOL success = [archive extractBufferedDataFromFileInfo:fileInfo
+//                                                  error:&error
+//                                                 action:
+//                                                         ^(NSData *dataChunk, CGFloat percentDecompressed) {
+//                                                             NSLog(@"Decompressed: %f%%", percentDecompressed);
+//                                                             [reconstructedFile appendBytes:dataChunk.bytes
+//                                                                                     length:dataChunk.length];
+//                                                         }];
+//
+//    XCTAssertFalse(success, @"Failed to read buffered data");
+//    XCTAssertNotNil(error, @"Error reading buffered data");
+//
+//    NSData *originalFile = [NSData dataWithContentsOfURL:self.testFileURLs[extractedFile]];
+//    XCTAssertTrue([originalFile isEqualToData:reconstructedFile],
+//            @"File extracted in buffer not returned correctly");
+}
+
+- (void)testExtractBufferedDataFromFileInfo_ModifiedCRC_IgnoringMismatches
+{
+//    NSURL *archiveURL = self.testFileURLs[@"Modified CRC Archive.rar"];
+//    NSString *extractedFile = @"README.md";
+//    URKArchive *archive = [[URKArchive alloc] initWithURL:archiveURL error:nil];
+//    URKFileInfo *fileInfo = [self getFileInfoByPath:archive filePath: extractedFile];
+//    archive.ignoreCRCMismatches = YES;
+//
+//    NSError *error = nil;
+//    NSMutableData *reconstructedFile = [NSMutableData data];
+//    BOOL success = [archive extractBufferedDataFromFileInfo:fileInfo
+//                                                  error:&error
+//                                                 action:
+//                                                         ^(NSData *dataChunk, CGFloat percentDecompressed) {
+//                                                             NSLog(@"Decompressed: %f%%", percentDecompressed);
+//                                                             [reconstructedFile appendBytes:dataChunk.bytes
+//                                                                                     length:dataChunk.length];
+//                                                         }];
+//
+//    XCTAssertTrue(success, @"Failed to read buffered data");
+//    XCTAssertNil(error, @"Error reading buffered data");
+//    XCTAssertGreaterThan(reconstructedFile.length, 0, @"No data returned");
+//
+//    NSData *originalFile = [NSData dataWithContentsOfURL:self.testFileURLs[extractedFile]];
+//    XCTAssertTrue([originalFile isEqualToData:reconstructedFile],
+//            @"File extracted in buffer not returned correctly");
 }
 
 #if !TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200


### PR DESCRIPTION
Changes overview:

1. A new **extractBufferedDataFromFileInfo** is added for extract buffer data from **URKFileInfo** instance, which is much faster than the old filename based method "extractBufferedData"
2. A new property "closestOffsetToHeader" is added to "URKFileInfo", which will be set in "**readHeader**" method. By doing this we can have an intact `unrar` lib.
3. "extractData" is speedup in the same way too.

I also need some helps with my PR:

- I copy the old unit tests of "extractBufferedData" to test my new method, but two of them is failed due to the CRC corruption, the "**listFileInfo**" method seems to ignore **ignoreCRCMismatches** flag, so I need a workaround to get URKFileInfo instance from a CRC corrupted archive.
- I copy and redeclare a private struct "**DataSet**" from `unrar` In order to call `data->Arc.Seek` API, I don't know if this is the right thing to do, I'm not familiar with C-like language, maybe you have a better idea?
