### PR TITLE
Addressing crash report involving strlen

### DIFF
--- a/Classes/URKArchive.mm
+++ b/Classes/URKArchive.mm
@@ -1343,9 +1343,7 @@ int CALLBACK AllowCancellationCallbackProc(UINT msg, long UserData, long P1, lon
 
     URKLogDebug("Setting archive name...");
     
-    const char *filenameData = (const char *) [rarFile UTF8String];
-    self.flags->ArcName = new char[strlen(filenameData) + 1];
-    strcpy(self.flags->ArcName, filenameData);
+    self.flags->ArcName = strdup(rarFile.UTF8String);
     self.flags->OpenMode = (uint)mode;
     self.flags->OpFlags = self.ignoreCRCMismatches ? ROADOF_KEEPBROKEN : 0;
 

--- a/Classes/UnrarKitMacros.h
+++ b/Classes/UnrarKitMacros.h
@@ -60,7 +60,7 @@ __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000 \
 #import <os/activity.h>
 
 // Called from +[UnrarKit initialize] and +[URKArchiveTestCase setUp]
-extern os_log_t unrarkit_log; // Declared in URKArchive.m
+extern os_log_t unrarkit_log; // Declared in URKArchive.mm
 extern BOOL unrarkitIsAtLeast10_13SDK; // Declared in URKArchive.m
 #define URKLogInit() \
     unrarkit_log = os_log_create("com.abbey-code.UnrarKit", "General"); \


### PR DESCRIPTION
I got a crash report in UnrarKit in this code:

```objc
    const char *filenameData = (const char *) [rarFile UTF8String];
    self.flags->ArcName = new char[strlen(filenameData) + 1]; // <---- Crash here
    strcpy(self.flags->ArcName, filenameData);
```

I was unable to reproduce, but it seems like since ArcName has a life beyond `-_unrarOpenFile:inMode:withPassword:error:`, it should be allocated on the heap instead of the stack.